### PR TITLE
Change starting square size to map setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ make install
 
 `make build` creates a versioned Factorio mod zip in `./build/` using the `name` and `version` from `info.json`.
 
+The starting square size is a per-save map setting (`runtime-global` in Factorio terms). Set it when creating a run. Changing it after the bootstrap surface already exists does not resize the current save.
+
 `make install` builds the zip and copies it into your local Factorio mods directory. By default the install script auto-detects:
 
 - macOS: `~/Library/Application Support/factorio/mods`

--- a/control.lua
+++ b/control.lua
@@ -3,14 +3,16 @@ local SETTING_STARTING_SQUARE_SIZE = "fes-starting-square-size"
 local FLOOR_TILE_NAME = "grass-1"
 local CHART_MARGIN = 1
 
-local function get_square_size()
-  local value = settings.startup[SETTING_STARTING_SQUARE_SIZE].value
-
+local function normalize_square_size(value)
   if value % 2 == 0 then
     value = value + 1
   end
 
   return value
+end
+
+local function get_square_size()
+  return normalize_square_size(settings.global[SETTING_STARTING_SQUARE_SIZE].value)
 end
 
 local function get_square_bounds(size)
@@ -151,6 +153,25 @@ local function refresh_spawn_routing()
   end
 end
 
+local function notify_square_size_change_applies_to_new_saves()
+  local requested_size = normalize_square_size(settings.global[SETTING_STARTING_SQUARE_SIZE].value)
+
+  if storage.bootstrap and storage.bootstrap.square_size == requested_size then
+    return
+  end
+
+  game.print(
+    {"",
+      "[Expanding Square] Starting square size changes only apply to new saves. ",
+      "This save remains at ",
+      storage.bootstrap and storage.bootstrap.square_size or "?",
+      " and the current map setting is ",
+      requested_size,
+      "."
+    }
+  )
+end
+
 script.on_init(function()
   bootstrap_world()
 end)
@@ -177,5 +198,15 @@ script.on_event(defines.events.on_player_respawned, function(event)
 
   if player then
     teleport_player_to_square(player)
+  end
+end)
+
+script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
+  if event.setting ~= SETTING_STARTING_SQUARE_SIZE then
+    return
+  end
+
+  if storage.bootstrap then
+    notify_square_size_change_applies_to_new_saves()
   end
 end)

--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -2,4 +2,4 @@
 fes-starting-square-size=Starting square size
 
 [mod-setting-description]
-fes-starting-square-size=Side length of the initial fixed bootstrap square. Even values are rounded up to the next odd size so the spawn stays centered.
+fes-starting-square-size=Side length of the initial fixed bootstrap square for this save. Even values are rounded up to the next odd size so the spawn stays centered. Changing it after world creation does not resize the current square.

--- a/settings.lua
+++ b/settings.lua
@@ -2,7 +2,7 @@ data:extend({
   {
     type = "int-setting",
     name = "fes-starting-square-size",
-    setting_type = "startup",
+    setting_type = "runtime-global",
     default_value = 7,
     minimum_value = 3,
     maximum_value = 255,


### PR DESCRIPTION
## Summary

- change `fes-starting-square-size` from a startup setting to a per-save map setting (`runtime-global`)
- read the square size from `settings.global` in runtime setup
- notify players if they change the setting after bootstrap that it only applies to new saves
- document the new behavior in the README and setting description

## Testing

- `make build`
- `make install`

Local install updated for review on this machine.