### PR TITLE
Implement issue #9 research slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ The starting square size is a per-save map setting (`runtime-global` in Factorio
 
 Square growth now runs continuously in the background. Once per second the mod evaluates current counted-machine utilization inside the unlocked square, converts that into stored growth progress, and expands the square automatically whenever enough progress has accumulated for the next full ring.
 
+Research now includes custom expanding-square technologies:
+
+- `Expansion speed` is a repeatable research line that starts with red science, steps through vanilla-style science-pack bands over time, and multiplies the square growth rate by 5% per completed level.
+- Tiered `Dummy research` technologies are always available as explicit filler options for each science band, so labs can keep contributing utilization before later infinite research becomes relevant.
+
 For manual testing, enable the per-player `Developer mode` runtime setting. That adds an `Expand square` button to the top-left UI plus a debug panel showing utilization, growth progress, growth rate, and the counted-footprint breakdown by category and entity type.
 
 `make install` builds the zip and copies it into your local Factorio mods directory. By default the install script auto-detects:

--- a/control.lua
+++ b/control.lua
@@ -16,6 +16,14 @@ local UTILIZATION_UPDATE_INTERVAL_TICKS = 60
 local GROWTH_RATE_SIZE_DIVISOR = 12
 local LINE_PURCHASE_COST = 12
 local MAX_INGRESS_TIER = 4
+local EXPANSION_SPEED_RESEARCH_PER_LEVEL_MULTIPLIER = 0.05
+local EXPANSION_SPEED_RESEARCH_BANDS = {
+  {name = "fes-expansion-speed-1", start_level = 1},
+  {name = "fes-expansion-speed-2", start_level = 6},
+  {name = "fes-expansion-speed-3", start_level = 11},
+  {name = "fes-expansion-speed-4", start_level = 16},
+  {name = "fes-expansion-speed-5", start_level = 21}
+}
 local DIRECTION_BY_SIDE
 local OFFSET_BY_SIDE
 local INGRESS_TIER_DEFINITIONS
@@ -609,6 +617,20 @@ local function compute_growth_rate_per_second(square_size, utilization_ratio)
   return utilization_ratio * (square_size / GROWTH_RATE_SIZE_DIVISOR)
 end
 
+local function get_completed_expansion_speed_research_levels()
+  if not storage.bootstrap then
+    return 0
+  end
+
+  return storage.bootstrap.expansion_speed_research_levels or 0
+end
+
+local function get_expansion_speed_multiplier()
+  local levels = get_completed_expansion_speed_research_levels()
+
+  return math.pow(1 + EXPANSION_SPEED_RESEARCH_PER_LEVEL_MULTIPLIER, levels), levels
+end
+
 local function sort_breakdown_entries(entries_by_key)
   local entries = {}
 
@@ -634,6 +656,7 @@ end
 local function evaluate_utilization(surface, square_size)
   local square_bounds = get_square_bounds(square_size)
   local total_tiles = get_square_area(square_size)
+  local expansion_speed_multiplier, expansion_speed_research_levels = get_expansion_speed_multiplier()
   local metrics = {
     tick = game.tick,
     square_size = square_size,
@@ -641,8 +664,11 @@ local function evaluate_utilization(surface, square_size)
     active_footprint_tiles = 0,
     active_entity_count = 0,
     utilization_ratio = 0,
+    base_growth_rate_per_second = 0,
     growth_rate_per_second = 0,
     growth_rate_per_minute = 0,
+    expansion_speed_multiplier = expansion_speed_multiplier,
+    expansion_speed_research_levels = expansion_speed_research_levels,
     categories = build_empty_category_breakdown(),
     entity_types = {}
   }
@@ -670,7 +696,8 @@ local function evaluate_utilization(surface, square_size)
     metrics.utilization_ratio = metrics.active_footprint_tiles / total_tiles
   end
 
-  metrics.growth_rate_per_second = compute_growth_rate_per_second(square_size, metrics.utilization_ratio)
+  metrics.base_growth_rate_per_second = compute_growth_rate_per_second(square_size, metrics.utilization_ratio)
+  metrics.growth_rate_per_second = metrics.base_growth_rate_per_second * expansion_speed_multiplier
   metrics.growth_rate_per_minute = metrics.growth_rate_per_second * 60
   metrics.sorted_entity_types = sort_breakdown_entries(metrics.entity_types)
 
@@ -768,6 +795,7 @@ local function ensure_bootstrap_state_defaults()
   storage.bootstrap.expansions_completed = storage.bootstrap.expansions_completed or 0
   storage.bootstrap.growth_progress = storage.bootstrap.growth_progress or 0
   storage.bootstrap.ingress_tier = storage.bootstrap.ingress_tier or 1
+  storage.bootstrap.expansion_speed_research_levels = storage.bootstrap.expansion_speed_research_levels or 0
 end
 
 local function ensure_surface_dimensions(surface, target_surface_size)
@@ -1807,7 +1835,12 @@ local function build_debug_lines()
   lines[#lines + 1] = "Growth rate: " .. format_decimal(metrics.growth_rate_per_second) .. " tiles/s"
     .. " (" .. format_decimal(metrics.growth_rate_per_minute) .. " tiles/min)"
   lines[#lines + 1] = "Formula: growth/s = utilization x (square size / " .. GROWTH_RATE_SIZE_DIVISOR .. ")"
+  lines[#lines + 1] = "Research multiplier: " .. format_decimal(metrics.expansion_speed_multiplier)
+    .. "x from " .. metrics.expansion_speed_research_levels .. " expansion-speed levels"
   lines[#lines + 1] = "Current: " .. format_decimal(metrics.growth_rate_per_second)
+    .. " = " .. format_decimal(metrics.base_growth_rate_per_second)
+    .. " x " .. format_decimal(metrics.expansion_speed_multiplier)
+  lines[#lines + 1] = "Base: " .. format_decimal(metrics.base_growth_rate_per_second)
     .. " = " .. format_decimal(metrics.utilization_ratio)
     .. " x (" .. bootstrap.square_size .. " / " .. GROWTH_RATE_SIZE_DIVISOR .. ")"
   lines[#lines + 1] = "Progress: " .. format_decimal(bootstrap.growth_progress or 0)
@@ -2089,6 +2122,16 @@ update_utilization_metrics = function()
   return metrics
 end
 
+local function announce_expansion_speed_research(force)
+  local multiplier, levels = get_expansion_speed_multiplier()
+
+  force.print({
+    "message.fes-expansion-speed-updated",
+    levels,
+    format_decimal(multiplier)
+  })
+end
+
 local function advance_growth_from_utilization()
   local bootstrap = storage.bootstrap
 
@@ -2316,6 +2359,25 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
     if player then
       sync_dev_gui(player)
       sync_shop_gui(player)
+    end
+  end
+end)
+
+script.on_event(defines.events.on_research_finished, function(event)
+  local research = event.research
+
+  if not (research and research.valid and research.force) then
+    return
+  end
+
+  for _, band in ipairs(EXPANSION_SPEED_RESEARCH_BANDS) do
+    if research.name == band.name then
+      storage.bootstrap = storage.bootstrap or {}
+      storage.bootstrap.expansion_speed_research_levels = (storage.bootstrap.expansion_speed_research_levels or 0) + 1
+      update_utilization_metrics()
+      refresh_all_debug_guis()
+      announce_expansion_speed_research(research.force)
+      return
     end
   end
 end)

--- a/control.lua
+++ b/control.lua
@@ -18,11 +18,11 @@ local LINE_PURCHASE_COST = 12
 local MAX_INGRESS_TIER = 4
 local EXPANSION_SPEED_RESEARCH_PER_LEVEL_MULTIPLIER = 0.05
 local EXPANSION_SPEED_RESEARCH_BANDS = {
-  {name = "fes-expansion-speed-1", start_level = 1},
-  {name = "fes-expansion-speed-2", start_level = 6},
-  {name = "fes-expansion-speed-3", start_level = 11},
-  {name = "fes-expansion-speed-4", start_level = 16},
-  {name = "fes-expansion-speed-5", start_level = 21}
+  {name = "fes-expansion-speed-automation", start_level = 1},
+  {name = "fes-expansion-speed-logistic", start_level = 6},
+  {name = "fes-expansion-speed-chemical", start_level = 11},
+  {name = "fes-expansion-speed-production-utility", start_level = 16},
+  {name = "fes-expansion-speed-space", start_level = 21}
 }
 local DIRECTION_BY_SIDE
 local OFFSET_BY_SIDE

--- a/data.lua
+++ b/data.lua
@@ -17,7 +17,7 @@ local item_ingress_belt_tiers = {
 
 local expansion_speed_research_bands = {
   {
-    name = "fes-expansion-speed-1",
+    name = "fes-expansion-speed-automation",
     localised_name = {"technology-name.fes-expansion-speed"},
     icon = "__base__/graphics/icons/lab.png",
     order = "c-a[expansion-speed]-a[automation]",
@@ -29,28 +29,28 @@ local expansion_speed_research_bands = {
     }
   },
   {
-    name = "fes-expansion-speed-2",
+    name = "fes-expansion-speed-logistic",
     localised_name = {"technology-name.fes-expansion-speed"},
     icon = "__base__/graphics/icons/lab.png",
     order = "c-a[expansion-speed]-b[logistic]",
     count_formula = "75*(L-5)",
     start_level = 6,
     max_level = 10,
-    prerequisites = {"fes-expansion-speed-1"},
+    prerequisites = {"fes-expansion-speed-automation"},
     ingredients = {
       {"automation-science-pack", 1},
       {"logistic-science-pack", 1}
     }
   },
   {
-    name = "fes-expansion-speed-3",
+    name = "fes-expansion-speed-chemical",
     localised_name = {"technology-name.fes-expansion-speed"},
     icon = "__base__/graphics/icons/lab.png",
     order = "c-a[expansion-speed]-c[chemical]",
     count_formula = "125*(L-10)",
     start_level = 11,
     max_level = 15,
-    prerequisites = {"fes-expansion-speed-2"},
+    prerequisites = {"fes-expansion-speed-logistic"},
     ingredients = {
       {"automation-science-pack", 1},
       {"logistic-science-pack", 1},
@@ -58,14 +58,14 @@ local expansion_speed_research_bands = {
     }
   },
   {
-    name = "fes-expansion-speed-4",
+    name = "fes-expansion-speed-production-utility",
     localised_name = {"technology-name.fes-expansion-speed"},
     icon = "__base__/graphics/icons/lab.png",
     order = "c-a[expansion-speed]-d[production-utility]",
     count_formula = "200*(L-15)",
     start_level = 16,
     max_level = 20,
-    prerequisites = {"fes-expansion-speed-3"},
+    prerequisites = {"fes-expansion-speed-chemical"},
     ingredients = {
       {"automation-science-pack", 1},
       {"logistic-science-pack", 1},
@@ -75,14 +75,14 @@ local expansion_speed_research_bands = {
     }
   },
   {
-    name = "fes-expansion-speed-5",
+    name = "fes-expansion-speed-space",
     localised_name = {"technology-name.fes-expansion-speed"},
     icon = "__base__/graphics/icons/lab.png",
     order = "c-a[expansion-speed]-e[space]",
     count_formula = "300*(L-20)",
     start_level = 21,
     max_level = "infinite",
-    prerequisites = {"fes-expansion-speed-4"},
+    prerequisites = {"fes-expansion-speed-production-utility"},
     ingredients = {
       {"automation-science-pack", 1},
       {"logistic-science-pack", 1},

--- a/data.lua
+++ b/data.lua
@@ -15,6 +15,145 @@ local item_ingress_belt_tiers = {
   {key = "blue", prototype_name = "express-transport-belt"}
 }
 
+local expansion_speed_research_bands = {
+  {
+    name = "fes-expansion-speed-1",
+    localised_name = {"technology-name.fes-expansion-speed"},
+    icon = "__base__/graphics/icons/lab.png",
+    order = "c-a[expansion-speed]-a[automation]",
+    count_formula = "50*(L)",
+    start_level = 1,
+    max_level = 5,
+    ingredients = {
+      {"automation-science-pack", 1}
+    }
+  },
+  {
+    name = "fes-expansion-speed-2",
+    localised_name = {"technology-name.fes-expansion-speed"},
+    icon = "__base__/graphics/icons/lab.png",
+    order = "c-a[expansion-speed]-b[logistic]",
+    count_formula = "75*(L-5)",
+    start_level = 6,
+    max_level = 10,
+    prerequisites = {"fes-expansion-speed-1"},
+    ingredients = {
+      {"automation-science-pack", 1},
+      {"logistic-science-pack", 1}
+    }
+  },
+  {
+    name = "fes-expansion-speed-3",
+    localised_name = {"technology-name.fes-expansion-speed"},
+    icon = "__base__/graphics/icons/lab.png",
+    order = "c-a[expansion-speed]-c[chemical]",
+    count_formula = "125*(L-10)",
+    start_level = 11,
+    max_level = 15,
+    prerequisites = {"fes-expansion-speed-2"},
+    ingredients = {
+      {"automation-science-pack", 1},
+      {"logistic-science-pack", 1},
+      {"chemical-science-pack", 1}
+    }
+  },
+  {
+    name = "fes-expansion-speed-4",
+    localised_name = {"technology-name.fes-expansion-speed"},
+    icon = "__base__/graphics/icons/lab.png",
+    order = "c-a[expansion-speed]-d[production-utility]",
+    count_formula = "200*(L-15)",
+    start_level = 16,
+    max_level = 20,
+    prerequisites = {"fes-expansion-speed-3"},
+    ingredients = {
+      {"automation-science-pack", 1},
+      {"logistic-science-pack", 1},
+      {"chemical-science-pack", 1},
+      {"production-science-pack", 1},
+      {"utility-science-pack", 1}
+    }
+  },
+  {
+    name = "fes-expansion-speed-5",
+    localised_name = {"technology-name.fes-expansion-speed"},
+    icon = "__base__/graphics/icons/lab.png",
+    order = "c-a[expansion-speed]-e[space]",
+    count_formula = "300*(L-20)",
+    start_level = 21,
+    max_level = "infinite",
+    prerequisites = {"fes-expansion-speed-4"},
+    ingredients = {
+      {"automation-science-pack", 1},
+      {"logistic-science-pack", 1},
+      {"chemical-science-pack", 1},
+      {"production-science-pack", 1},
+      {"utility-science-pack", 1},
+      {"space-science-pack", 1}
+    }
+  }
+}
+
+local dummy_research_definitions = {
+  {
+    name = "fes-dummy-research-red",
+    icon = "__base__/graphics/icons/automation-science-pack.png",
+    order = "c-b[dummy-research]-a[automation]",
+    count_formula = "30*(L)",
+    ingredients = {
+      {"automation-science-pack", 1}
+    }
+  },
+  {
+    name = "fes-dummy-research-green",
+    icon = "__base__/graphics/icons/logistic-science-pack.png",
+    order = "c-b[dummy-research]-b[logistic]",
+    count_formula = "45*(L)",
+    ingredients = {
+      {"automation-science-pack", 1},
+      {"logistic-science-pack", 1}
+    }
+  },
+  {
+    name = "fes-dummy-research-blue",
+    icon = "__base__/graphics/icons/chemical-science-pack.png",
+    order = "c-b[dummy-research]-c[chemical]",
+    count_formula = "75*(L)",
+    ingredients = {
+      {"automation-science-pack", 1},
+      {"logistic-science-pack", 1},
+      {"chemical-science-pack", 1}
+    }
+  },
+  {
+    name = "fes-dummy-research-production-utility",
+    icon = "__base__/graphics/icons/production-science-pack.png",
+    order = "c-b[dummy-research]-d[production-utility]",
+    count_formula = "125*(L)",
+    ingredients = {
+      {"automation-science-pack", 1},
+      {"logistic-science-pack", 1},
+      {"chemical-science-pack", 1},
+      {"production-science-pack", 1},
+      {"utility-science-pack", 1}
+    }
+  },
+  {
+    name = "fes-dummy-research-space",
+    icon = "__base__/graphics/icons/space-science-pack.png",
+    order = "c-b[dummy-research]-e[space]",
+    count_formula = "200*(L)",
+    ingredients = {
+      {"automation-science-pack", 1},
+      {"logistic-science-pack", 1},
+      {"chemical-science-pack", 1},
+      {"production-science-pack", 1},
+      {"utility-science-pack", 1},
+      {"space-science-pack", 1}
+    }
+  }
+}
+
 local function ingress_item_name(resource)
   return "fes-" .. resource .. "-ingress"
 end
@@ -58,6 +197,56 @@ local function build_ingress_entity(definition, belt_tier_key, belt_prototype_na
   return source
 end
 
+local function build_expansion_speed_technology(definition)
+  return {
+    type = "technology",
+    name = definition.name,
+    localised_name = definition.localised_name,
+    localised_description = {"technology-description.fes-expansion-speed"},
+    icon = definition.icon,
+    icon_size = 64,
+    order = definition.order,
+    upgrade = true,
+    max_level = definition.max_level,
+    level = definition.start_level,
+    prerequisites = definition.prerequisites,
+    unit = {
+      count_formula = definition.count_formula,
+      ingredients = definition.ingredients,
+      time = 30
+    },
+    effects = {
+      {
+        type = "nothing",
+        effect_description = {"technology-effect.fes-expansion-speed"}
+      }
+    }
+  }
+end
+
+local function build_dummy_research(definition)
+  return {
+    type = "technology",
+    name = definition.name,
+    localised_description = {"technology-description." .. definition.name},
+    icon = definition.icon,
+    icon_size = 64,
+    order = definition.order,
+    max_level = "infinite",
+    unit = {
+      count_formula = definition.count_formula,
+      ingredients = definition.ingredients,
+      time = 30
+    },
+    effects = {
+      {
+        type = "nothing",
+        effect_description = {"technology-effect.fes-dummy-research"}
+      }
+    }
+  }
+end
+
 local prototypes = {}
 
 for _, definition in ipairs(ingress_resources) do
@@ -74,6 +263,14 @@ for _, definition in ipairs(ingress_resources) do
   else
     prototypes[#prototypes + 1] = build_ingress_entity(definition)
   end
+end
+
+for _, definition in ipairs(expansion_speed_research_bands) do
+  prototypes[#prototypes + 1] = build_expansion_speed_technology(definition)
+end
+
+for _, definition in ipairs(dummy_research_definitions) do
+  prototypes[#prototypes + 1] = build_dummy_research(definition)
 end
 
 data:extend(prototypes)

--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -43,6 +43,26 @@ fes-uranium-ore-ingress-anchor=Uranium ore ingress
 [entity-description]
 fes-ingress-anchor=Owned ingress anchor. Mine it to stash the line back into inventory.
 
+[technology-name]
+fes-expansion-speed=Expansion speed
+fes-dummy-research-red=Dummy research (automation)
+fes-dummy-research-green=Dummy research (logistic)
+fes-dummy-research-blue=Dummy research (chemical)
+fes-dummy-research-production-utility=Dummy research (production and utility)
+fes-dummy-research-space=Dummy research (space)
+
+[technology-description]
+fes-expansion-speed=Repeatable research that multiplies square growth speed. Later bands require the same broader science-pack sets as vanilla infinite research progression.
+fes-dummy-research-red=Always-available filler research for red-science labs when meaningful automation-tier research runs out.
+fes-dummy-research-green=Always-available filler research for red and green science bands.
+fes-dummy-research-blue=Always-available filler research for red, green, and blue science bands.
+fes-dummy-research-production-utility=Always-available filler research for production and utility science tiers.
+fes-dummy-research-space=Always-available filler research for post-rocket space-science labs.
+
+[technology-effect]
+fes-expansion-speed=Increases square growth rate from utilization.
+fes-dummy-research=Provides repeatable filler work for labs without changing other game rules.
+
 [message]
 fes-ingress-invalid-surface=Ingress lines can only be placed on the expanding-square surface.
 fes-ingress-invalid-edge=Ingress lines can only be placed on the current edge of the base.
@@ -55,3 +75,4 @@ fes-shop-prerequisite=You must unlock __1__ first.
 fes-shop-resource-unknown=That ingress resource is not available.
 fes-shop-ingress-max-tier=Ingress throughput is already at the maximum tier.
 fes-shop-purchased-ingress-tier=Upgraded ingress throughput to __1__ for __2__ expansion points. Remaining points: __3__.
+fes-expansion-speed-updated=Expansion speed research is now level __1__. Growth multiplier: __2__x.


### PR DESCRIPTION
## Summary
- add custom expansion-speed and dummy research technologies across vanilla-like science bands
- apply expansion-speed research as a growth-rate multiplier in the runtime growth loop and surface it in debug output
- document the new research slice and add player-facing localization for the new techs

Closes #9

## Verification
- `make build`