### PR TITLE
Fix upgraded ingress belt names

### DIFF
--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -32,13 +32,25 @@ fes-ingress-item=Place this on the current border to activate that owned input l
 
 [entity-name]
 fes-iron-ore-ingress-anchor=Iron ore ingress
+fes-iron-ore-ingress-anchor-red=Iron ore ingress (red belt)
+fes-iron-ore-ingress-anchor-blue=Iron ore ingress (blue belt)
 fes-copper-ore-ingress-anchor=Copper ore ingress
+fes-copper-ore-ingress-anchor-red=Copper ore ingress (red belt)
+fes-copper-ore-ingress-anchor-blue=Copper ore ingress (blue belt)
 fes-coal-ingress-anchor=Coal ingress
+fes-coal-ingress-anchor-red=Coal ingress (red belt)
+fes-coal-ingress-anchor-blue=Coal ingress (blue belt)
 fes-stone-ingress-anchor=Stone ingress
+fes-stone-ingress-anchor-red=Stone ingress (red belt)
+fes-stone-ingress-anchor-blue=Stone ingress (blue belt)
 fes-water-ingress-anchor=Water ingress
 fes-wood-ingress-anchor=Wood ingress
+fes-wood-ingress-anchor-red=Wood ingress (red belt)
+fes-wood-ingress-anchor-blue=Wood ingress (blue belt)
 fes-crude-oil-ingress-anchor=Crude oil ingress
 fes-uranium-ore-ingress-anchor=Uranium ore ingress
+fes-uranium-ore-ingress-anchor-red=Uranium ore ingress (red belt)
+fes-uranium-ore-ingress-anchor-blue=Uranium ore ingress (blue belt)
 
 [entity-description]
 fes-ingress-anchor=Owned ingress anchor. Mine it to stash the line back into inventory.


### PR DESCRIPTION
## Summary
- add missing locale names for upgraded red and blue item ingress anchors
- keep the existing base ingress names while giving upgraded variants readable labels
- closes #35

## Testing
- make build
- make install
