### PR TITLE
Implement issue #11: player readout and help tips

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -11,6 +11,7 @@ local STARTER_ANCHOR_OUTER_RING_WIDTH = 2
 local STARTER_ANCHOR_LAYOUT_VERSION = 8
 local DEV_EXPAND_BUTTON_NAME = "fes_dev_expand_button"
 local DEBUG_FRAME_NAME = "fes_debug_frame"
+local STATUS_FRAME_NAME = "fes_status_frame"
 local SHOP_BUTTON_NAME = "fes_shop_button"
 local SHOP_FRAME_NAME = "fes_shop_frame"
 local UTILIZATION_UPDATE_INTERVAL_TICKS = 60
@@ -113,6 +114,7 @@ INGRESS_TIER_DEFINITIONS = {
 
 local update_utilization_metrics
 local refresh_all_debug_guis
+local refresh_all_status_guis
 local print_ingress_placement_debug
 local snap_entity_position_to_tile
 local sync_all_shop_guis
@@ -1882,7 +1884,7 @@ local function ensure_debug_frame(player)
   })
 end
 
-local function build_debug_lines()
+local function build_status_lines()
   local bootstrap = storage.bootstrap
   local metrics = storage.utilization_metrics
   local lines = {}
@@ -1895,25 +1897,92 @@ local function build_debug_lines()
   local next_reward = get_next_expansion_tile_reward(bootstrap.square_size)
 
   lines[#lines + 1] = "Square: " .. bootstrap.square_size .. "x" .. bootstrap.square_size
+  lines[#lines + 1] = "Logistics setting: "
+    .. (is_logistic_network_automation_enabled() and "enabled" or "disabled")
   lines[#lines + 1] = "Utilization: " .. format_ratio_percent(metrics.utilization_ratio)
     .. " (" .. metrics.active_footprint_tiles .. " / " .. metrics.total_tiles .. " tiles)"
-  lines[#lines + 1] = "Active entities: " .. metrics.active_entity_count
   lines[#lines + 1] = "Growth rate: " .. format_decimal(metrics.growth_rate_per_second) .. " tiles/s"
     .. " (" .. format_decimal(metrics.growth_rate_per_minute) .. " tiles/min)"
-  lines[#lines + 1] = "Formula: growth/s = utilization x (square size / " .. GROWTH_RATE_SIZE_DIVISOR .. ")"
+  lines[#lines + 1] = "Progress: " .. format_decimal(bootstrap.growth_progress or 0)
+    .. " / " .. next_reward
   lines[#lines + 1] = "Research multiplier: " .. format_decimal(metrics.expansion_speed_multiplier)
     .. "x from " .. metrics.expansion_speed_research_levels .. " expansion-speed levels"
+  lines[#lines + 1] = "Active entities: " .. metrics.active_entity_count
+  lines[#lines + 1] = "Expansion points: " .. (bootstrap.expansion_points or 0)
+  lines[#lines + 1] = "Ingress tier: " .. build_ingress_tier_summary()
+  lines[#lines + 1] = "Next reward: " .. next_reward .. " tiles and " .. next_reward .. " expansion points"
+
+  return lines
+end
+
+local function ensure_status_frame(player)
+  local frame = player.gui.left[STATUS_FRAME_NAME]
+
+  if frame then
+    return frame
+  end
+
+  return player.gui.left.add({
+    type = "frame",
+    name = STATUS_FRAME_NAME,
+    direction = "vertical",
+    caption = {"gui.fes-status-title"}
+  })
+end
+
+local function refresh_status_gui(player)
+  if not (player and player.valid) then
+    return
+  end
+
+  local frame = player.gui.left[STATUS_FRAME_NAME]
+
+  if not frame then
+    return
+  end
+
+  frame.clear()
+
+  for _, line in ipairs(build_status_lines()) do
+    frame.add({
+      type = "label",
+      caption = line
+    })
+  end
+end
+
+local function sync_status_gui(player)
+  if not (player and player.valid) then
+    return
+  end
+
+  ensure_status_frame(player)
+  refresh_status_gui(player)
+end
+
+refresh_all_status_guis = function()
+  for _, player in pairs(game.players) do
+    sync_status_gui(player)
+  end
+end
+
+local function build_debug_lines()
+  local lines = build_status_lines()
+
+  if lines[1] == "No utilization data yet." then
+    return lines
+  end
+
+  local bootstrap = storage.bootstrap
+  local metrics = storage.utilization_metrics
+
+  lines[#lines + 1] = "Formula: growth/s = utilization x (square size / " .. GROWTH_RATE_SIZE_DIVISOR .. ")"
   lines[#lines + 1] = "Current: " .. format_decimal(metrics.growth_rate_per_second)
     .. " = " .. format_decimal(metrics.base_growth_rate_per_second)
     .. " x " .. format_decimal(metrics.expansion_speed_multiplier)
   lines[#lines + 1] = "Base: " .. format_decimal(metrics.base_growth_rate_per_second)
     .. " = " .. format_decimal(metrics.utilization_ratio)
     .. " x (" .. bootstrap.square_size .. " / " .. GROWTH_RATE_SIZE_DIVISOR .. ")"
-  lines[#lines + 1] = "Progress: " .. format_decimal(bootstrap.growth_progress or 0)
-    .. " / " .. next_reward
-  lines[#lines + 1] = "Expansion points: " .. (bootstrap.expansion_points or 0)
-  lines[#lines + 1] = "Ingress tier: " .. build_ingress_tier_summary()
-  lines[#lines + 1] = "Next reward: " .. next_reward .. " expansion points"
   lines[#lines + 1] = "Breakdown:"
 
   for _, key in ipairs(COUNTED_CATEGORY_ORDER) do
@@ -2121,6 +2190,7 @@ local function sync_shop_gui(player)
     return
   end
 
+  sync_status_gui(player)
   ensure_shop_button(player)
   refresh_shop_gui(player)
 end
@@ -2184,6 +2254,7 @@ update_utilization_metrics = function()
   local metrics = evaluate_utilization(surface, bootstrap.square_size)
 
   storage.utilization_metrics = metrics
+  refresh_all_status_guis()
 
   return metrics
 end
@@ -2247,6 +2318,7 @@ local function bootstrap_world()
 
   apply_logistic_network_setting_to_all_forces()
   update_utilization_metrics()
+  refresh_all_status_guis()
   sync_all_dev_guis()
   sync_all_shop_guis()
 end
@@ -2277,6 +2349,7 @@ local function refresh_spawn_routing()
 
   apply_logistic_network_setting_to_all_forces()
   update_utilization_metrics()
+  refresh_all_status_guis()
   sync_all_dev_guis()
   sync_all_shop_guis()
 end
@@ -2320,6 +2393,7 @@ script.on_event(defines.events.on_player_created, function(event)
 
   if player then
     teleport_player_to_square(player)
+    sync_status_gui(player)
     sync_dev_gui(player)
     sync_shop_gui(player)
   end
@@ -2330,6 +2404,7 @@ script.on_event(defines.events.on_player_respawned, function(event)
 
   if player then
     teleport_player_to_square(player)
+    sync_status_gui(player)
     sync_dev_gui(player)
     sync_shop_gui(player)
   end
@@ -2423,6 +2498,7 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
 
   if event.setting == SETTING_ENABLE_LOGISTIC_NETWORK_AUTOMATION then
     apply_logistic_network_setting_to_all_forces()
+    refresh_all_status_guis()
     return
   end
 
@@ -2432,6 +2508,7 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
     if player then
       sync_dev_gui(player)
       sync_shop_gui(player)
+      sync_status_gui(player)
     end
   end
 end)
@@ -2449,6 +2526,7 @@ script.on_event(defines.events.on_research_finished, function(event)
       storage.bootstrap.expansion_speed_research_levels = (storage.bootstrap.expansion_speed_research_levels or 0) + 1
       update_utilization_metrics()
       refresh_all_debug_guis()
+      refresh_all_status_guis()
       announce_expansion_speed_research(research.force)
       break
     end

--- a/data.lua
+++ b/data.lua
@@ -154,6 +154,43 @@ local dummy_research_definitions = {
   }
 }
 
+local tips_and_tricks_items = {
+  {
+    name = "fes-overview",
+    order = "a[overview]",
+    category = "fes-rules",
+    icon = "__base__/graphics/icons/map.png"
+  },
+  {
+    name = "fes-utilization-and-growth",
+    order = "b[utilization-and-growth]",
+    category = "fes-rules",
+    dependencies = {"fes-overview"},
+    icon = "__base__/graphics/icons/lab.png"
+  },
+  {
+    name = "fes-ingress-lines",
+    order = "c[ingress-lines]",
+    category = "fes-rules",
+    dependencies = {"fes-utilization-and-growth"},
+    icon = "__base__/graphics/icons/transport-belt.png"
+  },
+  {
+    name = "fes-research-and-rewards",
+    order = "d[research-and-rewards]",
+    category = "fes-rules",
+    dependencies = {"fes-ingress-lines"},
+    icon = "__base__/graphics/icons/utility-science-pack.png"
+  },
+  {
+    name = "fes-logistics-rule",
+    order = "e[logistics-rule]",
+    category = "fes-rules",
+    dependencies = {"fes-research-and-rewards"},
+    icon = "__base__/graphics/icons/logistic-robot.png"
+  }
+}
+
 local function ingress_item_name(resource)
   return "fes-" .. resource .. "-ingress"
 end
@@ -247,7 +284,28 @@ local function build_dummy_research(definition)
   }
 end
 
+local function build_tips_item(definition)
+  return {
+    type = "tips-and-tricks-item",
+    name = definition.name,
+    order = definition.order,
+    category = definition.category,
+    starting_status = "unlocked",
+    dependencies = definition.dependencies,
+    localised_name = {"tips-and-tricks-item-name." .. definition.name},
+    localised_description = {"tips-and-tricks-item-description." .. definition.name},
+    icon = definition.icon,
+    icon_size = 64
+  }
+end
+
 local prototypes = {}
+
+prototypes[#prototypes + 1] = {
+  type = "tips-and-tricks-item-category",
+  name = "fes-rules",
+  order = "o[factorio-expanding-square]"
+}
 
 for _, definition in ipairs(ingress_resources) do
   prototypes[#prototypes + 1] = build_ingress_item(definition)
@@ -271,6 +329,10 @@ end
 
 for _, definition in ipairs(dummy_research_definitions) do
   prototypes[#prototypes + 1] = build_dummy_research(definition)
+end
+
+for _, definition in ipairs(tips_and_tricks_items) do
+  prototypes[#prototypes + 1] = build_tips_item(definition)
 end
 
 data:extend(prototypes)

--- a/data.lua
+++ b/data.lua
@@ -156,38 +156,46 @@ local dummy_research_definitions = {
 
 local tips_and_tricks_items = {
   {
-    name = "fes-overview",
-    order = "a[overview]",
+    name = "fes-mod",
+    order = "a[mod]",
     category = "fes-rules",
-    icon = "__base__/graphics/icons/info.png"
+    icon = "__base__/graphics/icons/info.png",
+    is_title = true
+  },
+  {
+    name = "fes-overview",
+    order = "b[overview]",
+    category = "fes-rules",
+    icon = "__base__/graphics/icons/info.png",
+    indent = 1
   },
   {
     name = "fes-utilization-and-growth",
-    order = "b[utilization-and-growth]",
+    order = "c[utilization-and-growth]",
     category = "fes-rules",
-    dependencies = {"fes-overview"},
-    icon = "__base__/graphics/icons/lab.png"
+    icon = "__base__/graphics/icons/lab.png",
+    indent = 1
   },
   {
     name = "fes-ingress-lines",
-    order = "c[ingress-lines]",
+    order = "d[ingress-lines]",
     category = "fes-rules",
-    dependencies = {"fes-utilization-and-growth"},
-    icon = "__base__/graphics/icons/transport-belt.png"
+    icon = "__base__/graphics/icons/transport-belt.png",
+    indent = 1
   },
   {
     name = "fes-research-and-rewards",
-    order = "d[research-and-rewards]",
+    order = "e[research-and-rewards]",
     category = "fes-rules",
-    dependencies = {"fes-ingress-lines"},
-    icon = "__base__/graphics/icons/utility-science-pack.png"
+    icon = "__base__/graphics/icons/utility-science-pack.png",
+    indent = 1
   },
   {
     name = "fes-logistics-rule",
-    order = "e[logistics-rule]",
+    order = "f[logistics-rule]",
     category = "fes-rules",
-    dependencies = {"fes-research-and-rewards"},
-    icon = "__base__/graphics/icons/logistic-robot.png"
+    icon = "__base__/graphics/icons/logistic-robot.png",
+    indent = 1
   }
 }
 
@@ -291,7 +299,8 @@ local function build_tips_item(definition)
     order = definition.order,
     category = definition.category,
     starting_status = "unlocked",
-    dependencies = definition.dependencies,
+    indent = definition.indent,
+    is_title = definition.is_title,
     localised_name = {"tips-and-tricks-item-name." .. definition.name},
     localised_description = {"tips-and-tricks-item-description." .. definition.name},
     icon = definition.icon,

--- a/data.lua
+++ b/data.lua
@@ -159,7 +159,7 @@ local tips_and_tricks_items = {
     name = "fes-overview",
     order = "a[overview]",
     category = "fes-rules",
-    icon = "__base__/graphics/icons/map.png"
+    icon = "__base__/graphics/icons/info.png"
   },
   {
     name = "fes-utilization-and-growth",

--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -11,6 +11,7 @@ fes-dev-mode=Shows developer-only controls for manual expansion and the utilizat
 fes-ingress-placement-debug=Prints ingress placement coordinates and edge-check details when you place an ingress item.
 
 [gui]
+fes-status-title=Expanding Square
 fes-dev-expand-button=Expand square
 fes-debug-title=Expanding Square Debug
 fes-shop-button=Ingress shop
@@ -91,3 +92,20 @@ fes-shop-ingress-max-tier=Ingress throughput is already at the maximum tier.
 fes-shop-purchased-ingress-tier=Upgraded ingress throughput to __1__ for __2__ expansion points. Remaining points: __3__.
 fes-expansion-speed-updated=Expansion speed research is now level __1__. Growth multiplier: __2__x.
 fes-logistic-network-disabled=__1__ is disabled by this map setting.
+
+[tips-and-tricks-item-category-name]
+fes-rules=Expanding Square
+
+[tips-and-tricks-item-name]
+fes-overview=The expanding square
+fes-utilization-and-growth=Utilization and growth
+fes-ingress-lines=Ingress lines
+fes-research-and-rewards=Research and rewards
+fes-logistics-rule=Logistics automation rule
+
+[tips-and-tricks-item-description]
+fes-overview=This mod replaces the normal open map with a managed square that starts small and expands one ring at a time. The playable area is always the inside of the current square. Anything outside it is inaccessible void, and every expansion adds exactly one tile on each side.\n\nThe square is centered on the spawn and the newly unlocked ring is cleared for building. The run is meant to stay within this border, so compact layouts and rebuilds are part of the normal flow.
+fes-utilization-and-growth=Square growth runs continuously in the background. Once per second the mod checks the current square, counts the active machines that qualify, and converts that counted footprint into stored growth progress.\n\nUtilization is active counted-machine tiles divided by total unlocked tiles. Zero utilization gives zero growth. The current growth rate is utilization multiplied by square size divided by 12, then multiplied by the expansion-speed research bonus.\n\nThe status panel shows utilization, current growth rate, stored progress, and the next reward threshold.
+fes-ingress-lines=Resources do not come from patches inside the square. Instead, owned ingress anchors are placed on the current border and feed free raw resources inward from outside the map.\n\nThe starting lines are iron ore, copper ore, coal, stone, water, and wood. You can mine an owned ingress anchor to stash it, then place it again on another valid border tile for free. Item lines and fluid lines can share sides, but fluid anchors must keep at least one empty anchor tile between them.\n\nWhen the square expands, enabled ingress lines move outward automatically and keep the connection going. Disabled or stashed lines remain owned but do not feed resources until placed again.
+fes-research-and-rewards=Every expansion rewards expansion points equal to the number of newly unlocked tiles in that ring. Expansion points are spent in the ingress shop on additional lines and global ingress throughput upgrades.\n\nExpansion-speed research is repeatable and multiplies square growth speed. The mod also adds repeatable dummy research so labs can stay active before later infinite vanilla research becomes available.\n\nVanilla infinite research remains enabled after the normal rocket launch.
+fes-logistics-rule=Construction and deconstruction bots are allowed. Trains, handcrafting, and hand-feeding are also allowed.\n\nLogistic network automation is controlled by the map setting. When it is disabled, active provider chests, buffer chests, requester chests, and storage chests are blocked. Passive provider chests and logistic robots still work. When the setting is enabled, the logistic chest network behaves normally.

--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -97,6 +97,7 @@ fes-logistic-network-disabled=__1__ is disabled by this map setting.
 fes-rules=Expanding Square
 
 [tips-and-tricks-item-name]
+fes-mod=Factorio Expanding Square
 fes-overview=The expanding square
 fes-utilization-and-growth=Utilization and growth
 fes-ingress-lines=Ingress lines
@@ -104,6 +105,7 @@ fes-research-and-rewards=Research and rewards
 fes-logistics-rule=Logistics automation rule
 
 [tips-and-tricks-item-description]
+fes-mod=Core rules and mechanics for this mod.
 fes-overview=This mod replaces the normal open map with a managed square that starts small and expands one ring at a time. The playable area is always the inside of the current square. Anything outside it is inaccessible void, and every expansion adds exactly one tile on each side.\n\nThe square is centered on the spawn and the newly unlocked ring is cleared for building. The run is meant to stay within this border, so compact layouts and rebuilds are part of the normal flow.
 fes-utilization-and-growth=Square growth runs continuously in the background. Once per second the mod checks the current square, counts the active machines that qualify, and converts that counted footprint into stored growth progress.\n\nUtilization is active counted-machine tiles divided by total unlocked tiles. Zero utilization gives zero growth. The current growth rate is utilization multiplied by square size divided by 12, then multiplied by the expansion-speed research bonus.\n\nThe status panel shows utilization, current growth rate, stored progress, and the next reward threshold.
 fes-ingress-lines=Resources do not come from patches inside the square. Instead, owned ingress anchors are placed on the current border and feed free raw resources inward from outside the map.\n\nThe starting lines are iron ore, copper ore, coal, stone, water, and wood. You can mine an owned ingress anchor to stash it, then place it again on another valid border tile for free. Item lines and fluid lines can share sides, but fluid anchors must keep at least one empty anchor tile between them.\n\nWhen the square expands, enabled ingress lines move outward automatically and keep the connection going. Disabled or stashed lines remain owned but do not feed resources until placed again.


### PR DESCRIPTION
## Summary
- add a player-facing status panel for square metrics and current logistics setting
- add Factorio-style tips-and-tricks entries covering the core mod mechanics
- keep the developer debug panel, but reuse the new player status content as its base

## Verification
- ./scripts/build-mod.sh
/Users/mmmatt/projects/factorio-expanding-square/build/factorio-expanding-square_0.1.0.zip
- headless Factorio map creation with the built mod zip

Closes #11