### PR TITLE
Make starter anchors fully unwalkable

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1199,6 +1199,7 @@ local function ensure_anchor_slot_proxies(surface, square_size, starter_anchors)
   end
 
   local occupied_positions = {}
+  local valid_ring_positions = {}
 
   for _, anchor in ipairs(starter_anchors.anchors) do
     if anchor.position then
@@ -1208,6 +1209,7 @@ local function ensure_anchor_slot_proxies(surface, square_size, starter_anchors)
 
   for _, position in ipairs(get_anchor_ring_positions(square_size)) do
     local position_key = get_position_key(position)
+    valid_ring_positions[position_key] = true
     local proxy = find_entity_at_position(surface, ANCHOR_SLOT_PROXY_NAME, get_tile_center_position(position))
 
     if occupied_positions[position_key] then
@@ -1220,6 +1222,15 @@ local function ensure_anchor_slot_proxies(surface, square_size, starter_anchors)
         position = get_tile_center_position(position),
         force = game.forces.player
       })
+    end
+  end
+
+  for _, proxy in ipairs(surface.find_entities_filtered({name = ANCHOR_SLOT_PROXY_NAME})) do
+    local proxy_position = snap_entity_position_to_tile(proxy.position)
+    local position_key = get_position_key(proxy_position)
+
+    if not valid_ring_positions[position_key] or occupied_positions[position_key] then
+      proxy.destroy({raise_destroy = false})
     end
   end
 end
@@ -1927,8 +1938,13 @@ local function handle_managed_anchor_built(entity, actor)
   end
 
   local tile_position = snap_entity_position_to_tile(entity.position)
-  local side = get_playable_edge_side_for_position(bootstrap.square_size, tile_position)
-  local anchor_position = side and move_position(tile_position, side, 1) or nil
+  local side = get_anchor_side_for_position(bootstrap.square_size, tile_position)
+  local anchor_position = tile_position
+
+  if not side then
+    side = get_playable_edge_side_for_position(bootstrap.square_size, tile_position)
+    anchor_position = side and move_position(tile_position, side, 1) or nil
+  end
 
   if not side then
     reject_anchor_placement(entity, actor, {"message.fes-managed-line-invalid-edge"})

--- a/control.lua
+++ b/control.lua
@@ -1,4 +1,5 @@
 local SURFACE_NAME = "fes-bootstrap"
+local bootstrap_layout = require("lib.bootstrap_layout")
 local resource_balance = require("lib.resource_balance")
 local SETTING_STARTING_SQUARE_SIZE = "fes-starting-square-size"
 local SETTING_ENABLE_LOGISTIC_NETWORK_AUTOMATION = "fes-enable-logistic-network-automation"
@@ -260,20 +261,15 @@ local function is_logistic_network_automation_enabled()
 end
 
 local function get_square_bounds(size)
-  local left = -math.floor(size / 2)
-
-  return {
-    left_top = {x = left, y = left},
-    right_bottom = {x = left + size, y = left + size}
-  }
+  return bootstrap_layout.get_square_bounds(size)
 end
 
 local function get_surface_size(square_size)
-  return square_size + (STARTER_ANCHOR_OUTER_RING_WIDTH * 2)
+  return bootstrap_layout.get_surface_size(square_size, STARTER_ANCHOR_OUTER_RING_WIDTH)
 end
 
 local function get_anchor_bounds(square_size)
-  return get_square_bounds(square_size + 2)
+  return bootstrap_layout.get_anchor_bounds(square_size)
 end
 
 local function get_square_area(square_size)
@@ -333,10 +329,7 @@ local function get_next_expansion_tile_reward(square_size)
 end
 
 local function is_inside_bounds(bounds, position)
-  return position.x >= bounds.left_top.x
-    and position.x < bounds.right_bottom.x
-    and position.y >= bounds.left_top.y
-    and position.y < bounds.right_bottom.y
+  return bootstrap_layout.is_inside_bounds(bounds, position)
 end
 
 local function get_position_key(position)
@@ -488,53 +481,21 @@ local function move_position(position, side, distance)
 end
 
 local function get_anchor_side_for_position(square_size, position)
-  local bounds = get_anchor_bounds(square_size)
-  local min_x = bounds.left_top.x
-  local min_y = bounds.left_top.y
-  local max_x = bounds.right_bottom.x - 1
-  local max_y = bounds.right_bottom.y - 1
-
-  if position.y == min_y and position.x > min_x and position.x < max_x then
-    return "north"
-  end
-
-  if position.x == max_x and position.y > min_y and position.y < max_y then
-    return "east"
-  end
-
-  if position.y == max_y and position.x > min_x and position.x < max_x then
-    return "south"
-  end
-
-  if position.x == min_x and position.y > min_y and position.y < max_y then
-    return "west"
-  end
-
-  return nil
+  return bootstrap_layout.get_anchor_side_for_position(square_size, position)
 end
 
 local function is_anchor_ring_position(square_size, position)
-  return get_anchor_side_for_position(square_size, position) ~= nil
+  return bootstrap_layout.is_anchor_ring_position(square_size, position)
 end
 
 local function get_managed_tile_name(square_size, surface_size, position)
-  local square_bounds = get_square_bounds(square_size)
-
-  if is_inside_bounds(square_bounds, position) then
-    return FLOOR_TILE_NAME
-  end
-
-  local surface_bounds = get_square_bounds(surface_size)
-
-  if is_inside_bounds(surface_bounds, position) then
-    if is_anchor_ring_position(square_size, position) then
-      return FLOOR_TILE_NAME
-    end
-
-    return VOID_TILE_NAME
-  end
-
-  return nil
+  return bootstrap_layout.get_managed_tile_name(
+    square_size,
+    surface_size,
+    FLOOR_TILE_NAME,
+    VOID_TILE_NAME,
+    position
+  )
 end
 
 local function build_anchor_ring_tiles(square_size, surface_size, anchors)
@@ -555,6 +516,18 @@ local function build_anchor_ring_tiles(square_size, surface_size, anchors)
   end
 
   return tiles
+end
+
+local function refresh_managed_surface_tiles(surface, square_size, surface_size)
+  if not surface then
+    return
+  end
+
+  local tile_updates = build_anchor_ring_tiles(square_size, surface_size, {})
+
+  if #tile_updates > 0 then
+    surface.set_tiles(tile_updates, false, true, true, false)
+  end
 end
 
 local function build_bootstrap_tiles(square_size, surface_size, anchors)
@@ -2647,6 +2620,12 @@ script.on_configuration_changed(function()
   if storage.bootstrap then
     ensure_bootstrap_state_defaults()
     ensure_starter_anchor_state()
+    local surface = game.surfaces[storage.bootstrap.surface_name]
+
+    if surface then
+      refresh_managed_surface_tiles(surface, storage.bootstrap.square_size, storage.bootstrap.surface_size)
+    end
+
     refresh_spawn_routing()
     return
   end

--- a/control.lua
+++ b/control.lua
@@ -1855,6 +1855,57 @@ local function teleport_player_to_square(player)
   chart_play_area(player.force, surface, bootstrap.surface_size or bootstrap.square_size)
 end
 
+local function get_inward_position_for_anchor_ring(square_size, tile_position)
+  local side = get_anchor_side_for_position(square_size, tile_position)
+
+  if side == "north" then
+    return {x = tile_position.x + 0.5, y = tile_position.y + 1.5}
+  end
+
+  if side == "east" then
+    return {x = tile_position.x - 0.5, y = tile_position.y + 0.5}
+  end
+
+  if side == "south" then
+    return {x = tile_position.x + 0.5, y = tile_position.y - 0.5}
+  end
+
+  if side == "west" then
+    return {x = tile_position.x + 1.5, y = tile_position.y + 0.5}
+  end
+
+  return nil
+end
+
+local function keep_player_out_of_anchor_ring(player)
+  local bootstrap = storage.bootstrap
+
+  if not (player and player.valid and bootstrap and player.surface and player.surface.name == bootstrap.surface_name) then
+    return
+  end
+
+  local tile_position = snap_entity_position_to_tile(player.position)
+
+  if not is_anchor_ring_position(bootstrap.square_size, tile_position) then
+    return
+  end
+
+  local target_position = get_inward_position_for_anchor_ring(bootstrap.square_size, tile_position)
+
+  if not target_position then
+    return
+  end
+
+  local safe_position = player.surface.find_non_colliding_position("character", target_position, 1, 0.25)
+
+  if safe_position then
+    player.teleport(safe_position, player.surface)
+    return
+  end
+
+  teleport_player_to_square(player)
+end
+
 local function add_expansion_points(amount)
   storage.bootstrap.expansion_points = (storage.bootstrap.expansion_points or 0) + amount
 end
@@ -2652,6 +2703,14 @@ script.on_event(defines.events.on_player_respawned, function(event)
     sync_status_gui(player)
     sync_dev_gui(player)
     sync_shop_gui(player)
+  end
+end)
+
+script.on_event(defines.events.on_player_changed_position, function(event)
+  local player = game.get_player(event.player_index)
+
+  if player then
+    keep_player_out_of_anchor_ring(player)
   end
 end)
 

--- a/control.lua
+++ b/control.lua
@@ -1855,6 +1855,18 @@ local function teleport_player_to_square(player)
   chart_play_area(player.force, surface, bootstrap.surface_size or bootstrap.square_size)
 end
 
+local function store_player_safe_position(player)
+  if not (player and player.valid) then
+    return
+  end
+
+  storage.player_safe_positions = storage.player_safe_positions or {}
+  storage.player_safe_positions[player.index] = {
+    x = player.position.x,
+    y = player.position.y
+  }
+end
+
 local function get_inward_position_for_anchor_ring(square_size, tile_position)
   local side = get_anchor_side_for_position(square_size, tile_position)
 
@@ -1887,10 +1899,18 @@ local function keep_player_out_of_anchor_ring(player)
   local tile_position = snap_entity_position_to_tile(player.position)
 
   if not is_anchor_ring_position(bootstrap.square_size, tile_position) then
+    store_player_safe_position(player)
     return
   end
 
-  local target_position = get_inward_position_for_anchor_ring(bootstrap.square_size, tile_position)
+  player.walking_state = {
+    walking = false,
+    direction = player.walking_state.direction
+  }
+
+  local safe_positions = storage.player_safe_positions or {}
+  local target_position = safe_positions[player.index]
+    or get_inward_position_for_anchor_ring(bootstrap.square_size, tile_position)
 
   if not target_position then
     return
@@ -1904,6 +1924,7 @@ local function keep_player_out_of_anchor_ring(player)
   end
 
   teleport_player_to_square(player)
+  store_player_safe_position(player)
 end
 
 local function add_expansion_points(amount)
@@ -2604,6 +2625,7 @@ local function bootstrap_world()
 
   for _, player in pairs(game.players) do
     teleport_player_to_square(player)
+    store_player_safe_position(player)
   end
 
   apply_logistic_network_setting_to_all_forces()
@@ -2635,6 +2657,7 @@ local function refresh_spawn_routing()
 
   for _, player in pairs(game.players) do
     teleport_player_to_square(player)
+    store_player_safe_position(player)
   end
 
   apply_logistic_network_setting_to_all_forces()
@@ -2689,6 +2712,7 @@ script.on_event(defines.events.on_player_created, function(event)
 
   if player then
     teleport_player_to_square(player)
+    store_player_safe_position(player)
     sync_status_gui(player)
     sync_dev_gui(player)
     sync_shop_gui(player)
@@ -2700,6 +2724,7 @@ script.on_event(defines.events.on_player_respawned, function(event)
 
   if player then
     teleport_player_to_square(player)
+    store_player_safe_position(player)
     sync_status_gui(player)
     sync_dev_gui(player)
     sync_shop_gui(player)

--- a/control.lua
+++ b/control.lua
@@ -9,6 +9,8 @@ local FLOOR_TILE_NAME = "grass-1"
 local VOID_TILE_NAME = "out-of-map"
 local CHART_MARGIN = 1
 local ITEM_ANCHOR_INTERVAL_TICKS = 8
+local ANCHOR_SLOT_PROXY_NAME = "fes-anchor-slot-proxy"
+local PLACE_MANAGED_ANCHOR_INPUT_NAME = "fes-place-managed-anchor"
 local STARTER_ANCHOR_OUTER_RING_WIDTH = 2
 local STARTER_ANCHOR_LAYOUT_VERSION = 8
 local DEV_EXPAND_BUTTON_NAME = "fes_dev_expand_button"
@@ -920,7 +922,9 @@ local function is_egress_entity_name(entity_name)
 end
 
 local function is_managed_anchor_entity_name(entity_name)
-  return is_ingress_entity_name(entity_name) or is_egress_entity_name(entity_name)
+  return entity_name == ANCHOR_SLOT_PROXY_NAME
+    or is_ingress_entity_name(entity_name)
+    or is_egress_entity_name(entity_name)
 end
 
 local function does_anchor_match_entity_name(anchor, entity_name)
@@ -1167,6 +1171,52 @@ local function ensure_anchor_entity(surface, anchor)
   return entity
 end
 
+local function get_anchor_ring_positions(square_size)
+  local positions = {}
+  local bounds = get_anchor_bounds(square_size)
+
+  for _, side in ipairs({"north", "east", "south", "west"}) do
+    local side_positions = get_edge_positions(bounds, side)
+
+    for _, position in ipairs(side_positions) do
+      positions[#positions + 1] = position
+    end
+  end
+
+  return positions
+end
+
+local function ensure_anchor_slot_proxies(surface, square_size, starter_anchors)
+  if not (surface and starter_anchors) then
+    return
+  end
+
+  local occupied_positions = {}
+
+  for _, anchor in ipairs(starter_anchors.anchors) do
+    if anchor.position then
+      occupied_positions[get_position_key(anchor.position)] = true
+    end
+  end
+
+  for _, position in ipairs(get_anchor_ring_positions(square_size)) do
+    local position_key = get_position_key(position)
+    local proxy = find_entity_at_position(surface, ANCHOR_SLOT_PROXY_NAME, position)
+
+    if occupied_positions[position_key] then
+      if proxy and proxy.valid then
+        proxy.destroy({raise_destroy = false})
+      end
+    elseif not proxy then
+      surface.create_entity({
+        name = ANCHOR_SLOT_PROXY_NAME,
+        position = position,
+        force = game.forces.player
+      })
+    end
+  end
+end
+
 local function migrate_anchor_to_anchor_ring(square_size, anchor)
   if not (anchor and anchor.position and anchor.side) then
     return
@@ -1247,6 +1297,8 @@ local function ensure_starter_anchors()
       ensure_anchor_entity(surface, anchor)
     end
   end
+
+  ensure_anchor_slot_proxies(surface, bootstrap.square_size, starter_anchors)
 end
 
 local function pump_item_anchor(entity, resource, lane_index, item_count)
@@ -1580,6 +1632,113 @@ player_insert_or_spill = function(player, item_name)
   return false
 end
 
+local function get_cursor_managed_anchor(player)
+  if not (player and player.valid and player.cursor_stack and player.cursor_stack.valid_for_read) then
+    return nil, nil
+  end
+
+  local item_name = player.cursor_stack.name
+  local anchor = find_matching_stashed_anchor(item_name)
+
+  if not anchor then
+    return nil, nil
+  end
+
+  return anchor, item_name
+end
+
+local function consume_cursor_item(player, item_name)
+  if not (player and player.valid and player.cursor_stack and player.cursor_stack.valid_for_read) then
+    return false
+  end
+
+  if player.cursor_stack.name ~= item_name then
+    return false
+  end
+
+  if player.cursor_stack.count > 1 then
+    player.cursor_stack.count = player.cursor_stack.count - 1
+  else
+    player.cursor_stack.clear()
+  end
+
+  return true
+end
+
+local function get_selected_anchor_slot_proxy(player)
+  if not (player and player.valid and player.selected and player.selected.valid) then
+    return nil
+  end
+
+  if player.selected.name ~= ANCHOR_SLOT_PROXY_NAME then
+    return nil
+  end
+
+  return player.selected
+end
+
+local function destroy_player_anchor_preview(player_index)
+  local preview_ghosts = storage.anchor_preview_ghosts
+
+  if not preview_ghosts then
+    return
+  end
+
+  local ghost = preview_ghosts[player_index]
+
+  if ghost and ghost.valid then
+    ghost.destroy()
+  end
+
+  preview_ghosts[player_index] = nil
+end
+
+local function update_player_anchor_preview(player)
+  if not (player and player.valid) then
+    return
+  end
+
+  destroy_player_anchor_preview(player.index)
+
+  local bootstrap = storage.bootstrap
+
+  if not (bootstrap and player.surface and player.surface.name == bootstrap.surface_name) then
+    return
+  end
+
+  local proxy = get_selected_anchor_slot_proxy(player)
+  local anchor = get_cursor_managed_anchor(player)
+
+  if not (proxy and anchor) then
+    return
+  end
+
+  local tile_position = snap_entity_position_to_tile(proxy.position)
+  local side = get_anchor_side_for_position(bootstrap.square_size, tile_position)
+
+  if not side or is_fluid_anchor_too_close(anchor, tile_position, side) then
+    return
+  end
+
+  storage.anchor_preview_ghosts = storage.anchor_preview_ghosts or {}
+  storage.anchor_preview_ghosts[player.index] = rendering.draw_sprite({
+    sprite = "entity/" .. get_anchor_entity_name_for_current_tier(anchor),
+    target = {x = tile_position.x + 0.5, y = tile_position.y + 0.5},
+    surface = player.surface,
+    players = {player.index},
+    tint = {r = 1, g = 1, b = 1, a = 0.45},
+    x_scale = 0.9,
+    y_scale = 0.9,
+    render_layer = "object"
+  })
+end
+
+local function update_all_player_anchor_previews()
+  for _, player in pairs(game.players) do
+    update_player_anchor_preview(player)
+  end
+end
+
 local function get_owned_line_counts(resource)
   local starter_anchors = storage.starter_anchors
   local counts = {
@@ -1788,6 +1947,48 @@ local function handle_managed_anchor_built(entity, actor)
   sync_all_shop_guis()
 end
 
+local function handle_managed_anchor_slot_click(player)
+  local bootstrap = storage.bootstrap
+
+  if not (player and player.valid and bootstrap) then
+    return
+  end
+
+  local proxy = get_selected_anchor_slot_proxy(player)
+
+  if not proxy then
+    return
+  end
+
+  local anchor, item_name = get_cursor_managed_anchor(player)
+
+  if not (anchor and item_name) then
+    return
+  end
+
+  local tile_position = snap_entity_position_to_tile(proxy.position)
+  local side = get_anchor_side_for_position(bootstrap.square_size, tile_position)
+
+  if not side then
+    player.print({"message.fes-managed-line-invalid-edge"})
+    return
+  end
+
+  if is_fluid_anchor_too_close(anchor, tile_position, side) then
+    player.print({"message.fes-managed-line-fluid-gap-required"})
+    return
+  end
+
+  if not consume_cursor_item(player, item_name) then
+    return
+  end
+
+  assign_anchor_position(anchor, side, tile_position)
+  ensure_starter_anchors()
+  update_player_anchor_preview(player)
+  sync_all_shop_guis()
+end
+
 local function handle_anchor_mined(entity)
   if not (entity and entity.valid) then
     return
@@ -1797,6 +1998,7 @@ local function handle_anchor_mined(entity)
 
   if anchor then
     stash_anchor(anchor)
+    ensure_starter_anchors()
     sync_all_shop_guis()
   end
 end
@@ -2749,6 +2951,14 @@ script.on_event(defines.events.on_gui_click, function(event)
   end
 end)
 
+script.on_event(PLACE_MANAGED_ANCHOR_INPUT_NAME, function(event)
+  local player = game.get_player(event.player_index)
+
+  if player then
+    handle_managed_anchor_slot_click(player)
+  end
+end)
+
 script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
   if event.setting == SETTING_STARTING_SQUARE_SIZE then
     if storage.bootstrap then
@@ -2802,6 +3012,7 @@ end)
 script.on_nth_tick(ITEM_ANCHOR_INTERVAL_TICKS, function()
   ensure_starter_anchors()
   pump_starter_anchors()
+  update_all_player_anchor_previews()
 end)
 
 script.on_nth_tick(UTILIZATION_UPDATE_INTERVAL_TICKS, function()

--- a/control.lua
+++ b/control.lua
@@ -888,6 +888,13 @@ local function find_entity_at_position(surface, prototype_name, position)
   return entities[1]
 end
 
+local function get_tile_center_position(position)
+  return {
+    x = position.x + 0.5,
+    y = position.y + 0.5
+  }
+end
+
 local function configure_source_anchor_entity(entity, direction)
   if not (entity and entity.valid) then
     return
@@ -1201,7 +1208,7 @@ local function ensure_anchor_slot_proxies(surface, square_size, starter_anchors)
 
   for _, position in ipairs(get_anchor_ring_positions(square_size)) do
     local position_key = get_position_key(position)
-    local proxy = find_entity_at_position(surface, ANCHOR_SLOT_PROXY_NAME, position)
+    local proxy = find_entity_at_position(surface, ANCHOR_SLOT_PROXY_NAME, get_tile_center_position(position))
 
     if occupied_positions[position_key] then
       if proxy and proxy.valid then
@@ -1210,7 +1217,7 @@ local function ensure_anchor_slot_proxies(surface, square_size, starter_anchors)
     elseif not proxy then
       surface.create_entity({
         name = ANCHOR_SLOT_PROXY_NAME,
-        position = position,
+        position = get_tile_center_position(position),
         force = game.forces.player
       })
     end

--- a/control.lua
+++ b/control.lua
@@ -488,6 +488,10 @@ local function is_anchor_ring_position(square_size, position)
   return bootstrap_layout.is_anchor_ring_position(square_size, position)
 end
 
+local function get_playable_edge_side_for_position(square_size, position)
+  return bootstrap_layout.get_playable_edge_side_for_position(square_size, position)
+end
+
 local function get_managed_tile_name(square_size, surface_size, position)
   return bootstrap_layout.get_managed_tile_name(
     square_size,
@@ -1021,6 +1025,20 @@ local function place_anchor(anchor, entity, square_size)
   anchor.entity_name = get_anchor_entity_name_for_current_tier(anchor)
   anchor.entity = entity
   configure_source_anchor_entity(entity, anchor.direction)
+
+  return true
+end
+
+local function assign_anchor_position(anchor, side, position)
+  if not (anchor and side and position) then
+    return false
+  end
+
+  anchor.position = position
+  anchor.side = side
+  anchor.direction = DIRECTION_BY_SIDE[side]
+  anchor.entity_name = get_anchor_entity_name_for_current_tier(anchor)
+  anchor.entity = nil
 
   return true
 end
@@ -1742,10 +1760,9 @@ local function handle_managed_anchor_built(entity, actor)
     print_ingress_placement_debug(actor, bootstrap.square_size, entity.position)
   end
 
-  local side = get_anchor_side_for_position(
-    bootstrap.square_size,
-    snap_entity_position_to_tile(entity.position)
-  )
+  local tile_position = snap_entity_position_to_tile(entity.position)
+  local side = get_playable_edge_side_for_position(bootstrap.square_size, tile_position)
+  local anchor_position = side and move_position(tile_position, side, 1) or nil
 
   if not side then
     reject_anchor_placement(entity, actor, {"message.fes-managed-line-invalid-edge"})
@@ -1759,15 +1776,13 @@ local function handle_managed_anchor_built(entity, actor)
     return
   end
 
-  if is_fluid_anchor_too_close(anchor, snap_entity_position_to_tile(entity.position), side) then
+  if is_fluid_anchor_too_close(anchor, anchor_position, side) then
     reject_anchor_placement(entity, actor, {"message.fes-managed-line-fluid-gap-required"})
     return
   end
 
-  if not place_anchor(anchor, entity, bootstrap.square_size) then
-    reject_anchor_placement(entity, actor, {"message.fes-managed-line-invalid-edge"})
-    return
-  end
+  entity.destroy({raise_destroy = false})
+  assign_anchor_position(anchor, side, anchor_position)
 
   ensure_starter_anchors()
   sync_all_shop_guis()
@@ -1853,78 +1868,6 @@ local function teleport_player_to_square(player)
   player.force.set_spawn_position(target_position, surface)
   player.teleport(target_position, surface)
   chart_play_area(player.force, surface, bootstrap.surface_size or bootstrap.square_size)
-end
-
-local function store_player_safe_position(player)
-  if not (player and player.valid) then
-    return
-  end
-
-  storage.player_safe_positions = storage.player_safe_positions or {}
-  storage.player_safe_positions[player.index] = {
-    x = player.position.x,
-    y = player.position.y
-  }
-end
-
-local function get_inward_position_for_anchor_ring(square_size, tile_position)
-  local side = get_anchor_side_for_position(square_size, tile_position)
-
-  if side == "north" then
-    return {x = tile_position.x + 0.5, y = tile_position.y + 1.5}
-  end
-
-  if side == "east" then
-    return {x = tile_position.x - 0.5, y = tile_position.y + 0.5}
-  end
-
-  if side == "south" then
-    return {x = tile_position.x + 0.5, y = tile_position.y - 0.5}
-  end
-
-  if side == "west" then
-    return {x = tile_position.x + 1.5, y = tile_position.y + 0.5}
-  end
-
-  return nil
-end
-
-local function keep_player_out_of_anchor_ring(player)
-  local bootstrap = storage.bootstrap
-
-  if not (player and player.valid and bootstrap and player.surface and player.surface.name == bootstrap.surface_name) then
-    return
-  end
-
-  local tile_position = snap_entity_position_to_tile(player.position)
-
-  if not is_anchor_ring_position(bootstrap.square_size, tile_position) then
-    store_player_safe_position(player)
-    return
-  end
-
-  player.walking_state = {
-    walking = false,
-    direction = player.walking_state.direction
-  }
-
-  local safe_positions = storage.player_safe_positions or {}
-  local target_position = safe_positions[player.index]
-    or get_inward_position_for_anchor_ring(bootstrap.square_size, tile_position)
-
-  if not target_position then
-    return
-  end
-
-  local safe_position = player.surface.find_non_colliding_position("character", target_position, 1, 0.25)
-
-  if safe_position then
-    player.teleport(safe_position, player.surface)
-    return
-  end
-
-  teleport_player_to_square(player)
-  store_player_safe_position(player)
 end
 
 local function add_expansion_points(amount)
@@ -2124,7 +2067,7 @@ end
 
 local function build_ingress_edge_check_debug(square_size, position)
   local tile_position = snap_entity_position_to_tile(position)
-  local bounds = get_anchor_bounds(square_size)
+  local bounds = get_square_bounds(square_size)
   local min_x = bounds.left_top.x
   local min_y = bounds.left_top.y
   local max_x = bounds.right_bottom.x - 1
@@ -2133,22 +2076,24 @@ local function build_ingress_edge_check_debug(square_size, position)
   local east_match = tile_position.x == max_x and tile_position.y > min_y and tile_position.y < max_y
   local south_match = tile_position.y == max_y and tile_position.x > min_x and tile_position.x < max_x
   local west_match = tile_position.x == min_x and tile_position.y > min_y and tile_position.y < max_y
-  local detected_side = get_anchor_side_for_position(square_size, tile_position)
+  local detected_side = get_playable_edge_side_for_position(square_size, tile_position)
+  local anchor_position = detected_side and move_position(tile_position, detected_side, 1) or nil
 
   return table.concat({
     "[Expanding Square] Ingress placement debug",
     "raw_position=" .. format_position(position),
     "tile_position=" .. format_position(tile_position),
     "square_size=" .. square_size,
-    "anchor_bounds.left_top=" .. format_position(bounds.left_top),
-    "anchor_bounds.right_bottom=" .. format_position(bounds.right_bottom),
+    "playable_bounds.left_top=" .. format_position(bounds.left_top),
+    "playable_bounds.right_bottom=" .. format_position(bounds.right_bottom),
     "min=(" .. min_x .. ", " .. min_y .. ")",
     "max=(" .. max_x .. ", " .. max_y .. ")",
     "north=" .. tostring(north_match),
     "east=" .. tostring(east_match),
     "south=" .. tostring(south_match),
     "west=" .. tostring(west_match),
-    "detected_side=" .. tostring(detected_side)
+    "detected_side=" .. tostring(detected_side),
+    "anchor_position=" .. format_position(anchor_position)
   }, " | ")
 end
 
@@ -2625,7 +2570,6 @@ local function bootstrap_world()
 
   for _, player in pairs(game.players) do
     teleport_player_to_square(player)
-    store_player_safe_position(player)
   end
 
   apply_logistic_network_setting_to_all_forces()
@@ -2657,7 +2601,6 @@ local function refresh_spawn_routing()
 
   for _, player in pairs(game.players) do
     teleport_player_to_square(player)
-    store_player_safe_position(player)
   end
 
   apply_logistic_network_setting_to_all_forces()
@@ -2712,7 +2655,6 @@ script.on_event(defines.events.on_player_created, function(event)
 
   if player then
     teleport_player_to_square(player)
-    store_player_safe_position(player)
     sync_status_gui(player)
     sync_dev_gui(player)
     sync_shop_gui(player)
@@ -2724,18 +2666,9 @@ script.on_event(defines.events.on_player_respawned, function(event)
 
   if player then
     teleport_player_to_square(player)
-    store_player_safe_position(player)
     sync_status_gui(player)
     sync_dev_gui(player)
     sync_shop_gui(player)
-  end
-end)
-
-script.on_event(defines.events.on_player_changed_position, function(event)
-  local player = game.get_player(event.player_index)
-
-  if player then
-    keep_player_out_of_anchor_ring(player)
   end
 end)
 

--- a/data.lua
+++ b/data.lua
@@ -244,6 +244,37 @@ local function build_ingress_item(definition)
   }
 end
 
+local function remove_collision_layers(collision_mask, layers_to_remove)
+  if not collision_mask then
+    return collision_mask
+  end
+
+  if collision_mask.layers then
+    for layer_name in pairs(layers_to_remove) do
+      collision_mask.layers[layer_name] = nil
+    end
+
+    return collision_mask
+  end
+
+  local filtered_mask = {}
+
+  for _, layer_name in ipairs(collision_mask) do
+    if not layers_to_remove[layer_name] then
+      filtered_mask[#filtered_mask + 1] = layer_name
+    end
+  end
+
+  return filtered_mask
+end
+
+local function allow_anchor_on_out_of_map(source)
+  source.collision_mask = remove_collision_layers(source.collision_mask, {
+    ["ground-tile"] = true,
+    ground_tile = true
+  })
+end
+
 local function build_ingress_entity(definition, belt_tier_key, belt_prototype_name)
   local source = definition.kind == "fluid"
     and table.deepcopy(data.raw.pipe.pipe)
@@ -257,6 +288,7 @@ local function build_ingress_entity(definition, belt_tier_key, belt_prototype_na
   source.minable = {mining_time = 0.1, result = item_name}
   source.placeable_by = {item = item_name, count = 1}
   source.next_upgrade = nil
+  allow_anchor_on_out_of_map(source)
 
   return source
 end
@@ -286,6 +318,7 @@ local function build_egress_entity(definition)
   source.minable = {mining_time = 0.1, result = item_name}
   source.placeable_by = {item = item_name, count = 1}
   source.next_upgrade = nil
+  allow_anchor_on_out_of_map(source)
 
   return source
 end

--- a/data.lua
+++ b/data.lua
@@ -273,6 +273,7 @@ local function allow_anchor_on_out_of_map(source)
     ["ground-tile"] = true,
     ground_tile = true
   })
+  source.tile_buildability_rules = nil
 end
 
 local function build_ingress_entity(definition, belt_tier_key, belt_prototype_name)

--- a/data.lua
+++ b/data.lua
@@ -323,14 +323,12 @@ local function build_anchor_slot_proxy()
     selectable_in_game = true,
     collision_box = {{0, 0}, {0, 0}},
     collision_mask = {layers = {}},
-    selection_box = {{-0.45, -0.45}, {0.45, 0.45}},
+    selection_box = {{-0.5, -0.5}, {0.5, 0.5}},
     max_health = 1,
     render_layer = "object",
     picture = {
-      filename = "__base__/graphics/icons/info.png",
-      size = 64,
-      scale = 0.35,
-      tint = {r = 0.85, g = 0.85, b = 0.85, a = 0.35}
+      filename = "__core__/graphics/empty.png",
+      size = 1
     }
   }
 end

--- a/data.lua
+++ b/data.lua
@@ -339,6 +339,7 @@ local function build_anchor_place_input()
   return {
     type = "custom-input",
     name = "fes-place-managed-anchor",
+    key_sequence = "",
     linked_game_control = "build",
     consuming = "none",
     include_selected_prototype = true

--- a/data.lua
+++ b/data.lua
@@ -310,7 +310,7 @@ local function build_anchor_slot_proxy()
   return {
     type = "simple-entity-with-owner",
     name = "fes-anchor-slot-proxy",
-    icon = "__base__/graphics/icons/ghost.png",
+    icon = "__base__/graphics/icons/info.png",
     icon_size = 64,
     flags = {
       "not-on-map",
@@ -327,7 +327,7 @@ local function build_anchor_slot_proxy()
     max_health = 1,
     render_layer = "object",
     picture = {
-      filename = "__base__/graphics/icons/ghost.png",
+      filename = "__base__/graphics/icons/info.png",
       size = 64,
       scale = 0.35,
       tint = {r = 0.85, g = 0.85, b = 0.85, a = 0.35}

--- a/data.lua
+++ b/data.lua
@@ -239,8 +239,7 @@ local function build_ingress_item(definition)
     icon_size = 64,
     subgroup = definition.kind == "fluid" and "energy-pipe-distribution" or "belt",
     order = definition.order,
-    stack_size = 50,
-    place_result = ingress_entity_name(definition.resource, definition.kind == "item" and "yellow" or nil)
+    stack_size = 50
   }
 end
 
@@ -303,8 +302,46 @@ local function build_egress_item(definition)
     icon_size = 64,
     subgroup = "energy-pipe-distribution",
     order = definition.order,
-    stack_size = 50,
-    place_result = egress_entity_name(definition.resource)
+    stack_size = 50
+  }
+end
+
+local function build_anchor_slot_proxy()
+  return {
+    type = "simple-entity-with-owner",
+    name = "fes-anchor-slot-proxy",
+    icon = "__base__/graphics/icons/ghost.png",
+    icon_size = 64,
+    flags = {
+      "not-on-map",
+      "placeable-off-grid",
+      "not-blueprintable",
+      "not-deconstructable",
+      "not-flammable"
+    },
+    hidden_in_factoriopedia = true,
+    selectable_in_game = true,
+    collision_box = {{0, 0}, {0, 0}},
+    collision_mask = {},
+    selection_box = {{-0.45, -0.45}, {0.45, 0.45}},
+    max_health = 1,
+    render_layer = "object",
+    picture = {
+      filename = "__base__/graphics/icons/ghost.png",
+      size = 64,
+      scale = 0.35,
+      tint = {r = 0.85, g = 0.85, b = 0.85, a = 0.35}
+    }
+  }
+end
+
+local function build_anchor_place_input()
+  return {
+    type = "custom-input",
+    name = "fes-place-managed-anchor",
+    linked_game_control = "build",
+    consuming = "none",
+    include_selected_prototype = true
   }
 end
 
@@ -397,6 +434,9 @@ prototypes[#prototypes + 1] = {
   name = "fes-rules",
   order = "o[factorio-expanding-square]"
 }
+
+prototypes[#prototypes + 1] = build_anchor_slot_proxy()
+prototypes[#prototypes + 1] = build_anchor_place_input()
 
 for _, definition in ipairs(ingress_resources) do
   prototypes[#prototypes + 1] = build_ingress_item(definition)

--- a/data.lua
+++ b/data.lua
@@ -322,7 +322,7 @@ local function build_anchor_slot_proxy()
     hidden_in_factoriopedia = true,
     selectable_in_game = true,
     collision_box = {{0, 0}, {0, 0}},
-    collision_mask = {},
+    collision_mask = {layers = {}},
     selection_box = {{-0.45, -0.45}, {0.45, 0.45}},
     max_health = 1,
     render_layer = "object",

--- a/lib/bootstrap_layout.lua
+++ b/lib/bootstrap_layout.lua
@@ -54,6 +54,32 @@ function bootstrap_layout.is_anchor_ring_position(square_size, position)
   return bootstrap_layout.get_anchor_side_for_position(square_size, position) ~= nil
 end
 
+function bootstrap_layout.get_playable_edge_side_for_position(square_size, position)
+  local bounds = bootstrap_layout.get_square_bounds(square_size)
+  local min_x = bounds.left_top.x
+  local min_y = bounds.left_top.y
+  local max_x = bounds.right_bottom.x - 1
+  local max_y = bounds.right_bottom.y - 1
+
+  if position.y == min_y and position.x > min_x and position.x < max_x then
+    return "north"
+  end
+
+  if position.x == max_x and position.y > min_y and position.y < max_y then
+    return "east"
+  end
+
+  if position.y == max_y and position.x > min_x and position.x < max_x then
+    return "south"
+  end
+
+  if position.x == min_x and position.y > min_y and position.y < max_y then
+    return "west"
+  end
+
+  return nil
+end
+
 function bootstrap_layout.get_managed_tile_name(square_size, surface_size, floor_tile_name, void_tile_name, position)
   local square_bounds = bootstrap_layout.get_square_bounds(square_size)
 
@@ -64,10 +90,6 @@ function bootstrap_layout.get_managed_tile_name(square_size, surface_size, floor
   local surface_bounds = bootstrap_layout.get_square_bounds(surface_size)
 
   if bootstrap_layout.is_inside_bounds(surface_bounds, position) then
-    if bootstrap_layout.is_anchor_ring_position(square_size, position) then
-      return floor_tile_name
-    end
-
     return void_tile_name
   end
 

--- a/lib/bootstrap_layout.lua
+++ b/lib/bootstrap_layout.lua
@@ -64,6 +64,10 @@ function bootstrap_layout.get_managed_tile_name(square_size, surface_size, floor
   local surface_bounds = bootstrap_layout.get_square_bounds(surface_size)
 
   if bootstrap_layout.is_inside_bounds(surface_bounds, position) then
+    if bootstrap_layout.is_anchor_ring_position(square_size, position) then
+      return floor_tile_name
+    end
+
     return void_tile_name
   end
 

--- a/lib/bootstrap_layout.lua
+++ b/lib/bootstrap_layout.lua
@@ -1,0 +1,73 @@
+local bootstrap_layout = {}
+
+function bootstrap_layout.get_square_bounds(size)
+  local left = -math.floor(size / 2)
+
+  return {
+    left_top = {x = left, y = left},
+    right_bottom = {x = left + size, y = left + size}
+  }
+end
+
+function bootstrap_layout.get_surface_size(square_size, outer_ring_width)
+  return square_size + (outer_ring_width * 2)
+end
+
+function bootstrap_layout.get_anchor_bounds(square_size)
+  return bootstrap_layout.get_square_bounds(square_size + 2)
+end
+
+function bootstrap_layout.is_inside_bounds(bounds, position)
+  return position.x >= bounds.left_top.x
+    and position.x < bounds.right_bottom.x
+    and position.y >= bounds.left_top.y
+    and position.y < bounds.right_bottom.y
+end
+
+function bootstrap_layout.get_anchor_side_for_position(square_size, position)
+  local bounds = bootstrap_layout.get_anchor_bounds(square_size)
+  local min_x = bounds.left_top.x
+  local min_y = bounds.left_top.y
+  local max_x = bounds.right_bottom.x - 1
+  local max_y = bounds.right_bottom.y - 1
+
+  if position.y == min_y and position.x > min_x and position.x < max_x then
+    return "north"
+  end
+
+  if position.x == max_x and position.y > min_y and position.y < max_y then
+    return "east"
+  end
+
+  if position.y == max_y and position.x > min_x and position.x < max_x then
+    return "south"
+  end
+
+  if position.x == min_x and position.y > min_y and position.y < max_y then
+    return "west"
+  end
+
+  return nil
+end
+
+function bootstrap_layout.is_anchor_ring_position(square_size, position)
+  return bootstrap_layout.get_anchor_side_for_position(square_size, position) ~= nil
+end
+
+function bootstrap_layout.get_managed_tile_name(square_size, surface_size, floor_tile_name, void_tile_name, position)
+  local square_bounds = bootstrap_layout.get_square_bounds(square_size)
+
+  if bootstrap_layout.is_inside_bounds(square_bounds, position) then
+    return floor_tile_name
+  end
+
+  local surface_bounds = bootstrap_layout.get_square_bounds(surface_size)
+
+  if bootstrap_layout.is_inside_bounds(surface_bounds, position) then
+    return void_tile_name
+  end
+
+  return nil
+end
+
+return bootstrap_layout

--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -36,6 +36,7 @@ fes-ingress-item=Place this on the current border to activate that owned input l
 fes-egress-item=Place this on the current border to activate that owned output line.
 
 [entity-name]
+fes-anchor-slot-proxy=Anchor slot
 fes-iron-ore-ingress-anchor=Iron ore ingress
 fes-iron-ore-ingress-anchor-red=Iron ore ingress (red belt)
 fes-iron-ore-ingress-anchor-blue=Iron ore ingress (blue belt)
@@ -59,6 +60,7 @@ fes-uranium-ore-ingress-anchor-blue=Uranium ore ingress (blue belt)
 fes-sulfuric-acid-egress-anchor=Sulfuric acid egress
 
 [entity-description]
+fes-anchor-slot-proxy=Empty managed anchor slot.
 fes-ingress-anchor=Owned ingress anchor. Mine it to stash the line back into inventory.
 fes-egress-anchor=Owned egress anchor. Mine it to stash the line back into inventory.
 

--- a/tests/bootstrap_layout_spec.lua
+++ b/tests/bootstrap_layout_spec.lua
@@ -1,0 +1,62 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local bootstrap_layout = require("lib.bootstrap_layout")
+
+local function assert_equal(actual, expected, message)
+  if actual ~= expected then
+    error((message or "values differ") .. "\nexpected: " .. tostring(expected) .. "\nactual: " .. tostring(actual))
+  end
+end
+
+local function run_test(name, fn)
+  local ok, err = pcall(fn)
+
+  if not ok then
+    io.stderr:write("FAIL " .. name .. "\n" .. err .. "\n")
+    os.exit(1)
+  end
+
+  io.stdout:write("PASS " .. name .. "\n")
+end
+
+run_test("anchor ring tiles stay out-of-map", function()
+  local square_size = 12
+  local surface_size = bootstrap_layout.get_surface_size(square_size, 2)
+
+  assert_equal(
+    bootstrap_layout.get_managed_tile_name(square_size, surface_size, "grass-1", "out-of-map", {x = 0, y = -7}),
+    "out-of-map",
+    "north anchor ring should remain out-of-map"
+  )
+  assert_equal(
+    bootstrap_layout.get_managed_tile_name(square_size, surface_size, "grass-1", "out-of-map", {x = 6, y = 0}),
+    "out-of-map",
+    "east anchor ring should remain out-of-map"
+  )
+end)
+
+run_test("playable square stays walkable floor", function()
+  local square_size = 12
+  local surface_size = bootstrap_layout.get_surface_size(square_size, 2)
+
+  assert_equal(
+    bootstrap_layout.get_managed_tile_name(square_size, surface_size, "grass-1", "out-of-map", {x = 0, y = 0}),
+    "grass-1",
+    "the playable square should keep floor tiles"
+  )
+end)
+
+run_test("anchor side detection still targets the ingress ring", function()
+  local square_size = 12
+
+  assert_equal(
+    bootstrap_layout.get_anchor_side_for_position(square_size, {x = 0, y = -7}),
+    "north",
+    "starter anchors should still snap to the north ring"
+  )
+  assert_equal(
+    bootstrap_layout.get_anchor_side_for_position(square_size, {x = 6, y = 0}),
+    "east",
+    "starter anchors should still snap to the east ring"
+  )
+end)

--- a/tests/bootstrap_layout_spec.lua
+++ b/tests/bootstrap_layout_spec.lua
@@ -19,19 +19,19 @@ local function run_test(name, fn)
   io.stdout:write("PASS " .. name .. "\n")
 end
 
-run_test("anchor ring tiles stay buildable floor", function()
+run_test("anchor ring tiles stay out-of-map", function()
   local square_size = 12
   local surface_size = bootstrap_layout.get_surface_size(square_size, 2)
 
   assert_equal(
     bootstrap_layout.get_managed_tile_name(square_size, surface_size, "grass-1", "out-of-map", {x = 0, y = -7}),
-    "grass-1",
-    "north anchor ring should stay buildable"
+    "out-of-map",
+    "north anchor ring should remain out-of-map"
   )
   assert_equal(
     bootstrap_layout.get_managed_tile_name(square_size, surface_size, "grass-1", "out-of-map", {x = 6, y = 0}),
-    "grass-1",
-    "east anchor ring should stay buildable"
+    "out-of-map",
+    "east anchor ring should remain out-of-map"
   )
 end)
 
@@ -69,5 +69,20 @@ run_test("anchor side detection still targets the ingress ring", function()
     bootstrap_layout.get_anchor_side_for_position(square_size, {x = 6, y = 0}),
     "east",
     "starter anchors should still snap to the east ring"
+  )
+end)
+
+run_test("playable edge detection resolves the inner placement strip", function()
+  local square_size = 12
+
+  assert_equal(
+    bootstrap_layout.get_playable_edge_side_for_position(square_size, {x = 0, y = -6}),
+    "north",
+    "players should place north anchors from the inner edge"
+  )
+  assert_equal(
+    bootstrap_layout.get_playable_edge_side_for_position(square_size, {x = 5, y = 0}),
+    "east",
+    "players should place east anchors from the inner edge"
   )
 end)

--- a/tests/bootstrap_layout_spec.lua
+++ b/tests/bootstrap_layout_spec.lua
@@ -19,19 +19,19 @@ local function run_test(name, fn)
   io.stdout:write("PASS " .. name .. "\n")
 end
 
-run_test("anchor ring tiles stay out-of-map", function()
+run_test("anchor ring tiles stay buildable floor", function()
   local square_size = 12
   local surface_size = bootstrap_layout.get_surface_size(square_size, 2)
 
   assert_equal(
     bootstrap_layout.get_managed_tile_name(square_size, surface_size, "grass-1", "out-of-map", {x = 0, y = -7}),
-    "out-of-map",
-    "north anchor ring should remain out-of-map"
+    "grass-1",
+    "north anchor ring should stay buildable"
   )
   assert_equal(
     bootstrap_layout.get_managed_tile_name(square_size, surface_size, "grass-1", "out-of-map", {x = 6, y = 0}),
-    "out-of-map",
-    "east anchor ring should remain out-of-map"
+    "grass-1",
+    "east anchor ring should stay buildable"
   )
 end)
 
@@ -43,6 +43,17 @@ run_test("playable square stays walkable floor", function()
     bootstrap_layout.get_managed_tile_name(square_size, surface_size, "grass-1", "out-of-map", {x = 0, y = 0}),
     "grass-1",
     "the playable square should keep floor tiles"
+  )
+end)
+
+run_test("outer perimeter outside the anchor ring stays out-of-map", function()
+  local square_size = 12
+  local surface_size = bootstrap_layout.get_surface_size(square_size, 2)
+
+  assert_equal(
+    bootstrap_layout.get_managed_tile_name(square_size, surface_size, "grass-1", "out-of-map", {x = 0, y = -8}),
+    "out-of-map",
+    "the outer perimeter should remain void"
   )
 end)
 


### PR DESCRIPTION
Closes #20

## Summary
- make the full ingress/egress perimeter use out-of-map tiles so starter anchors are never walkable
- allow managed ingress/egress anchor entities to exist on out-of-map so belts and pipes can still connect from the playable square
- refresh perimeter tiles on configuration changes and cover the layout rules with a focused unit spec