### PR TITLE
Move ingress upgrades to research and raise line costs

### DIFF
--- a/FEATURE_LIST.md
+++ b/FEATURE_LIST.md
@@ -72,16 +72,15 @@ This document lists planned features for `factorio-expanding-square`, grouped fi
 
 - Item lines start at single yellow-belt-lane equivalent
 - Fluid lines start at the matching lowest fluid ingress tier
-- Global ingress upgrade affects all item and fluid lines
-- Global ingress upgrades apply retroactively to existing and stashed lines
-- Later ingress upgrade enables double-lane item throughput on one anchor
+- Research-driven ingress upgrades affect all item and fluid lines
+- Ingress upgrades apply retroactively to existing and stashed lines
+- Logistics unlocks dual-lane yellow ingress, Logistics 2 unlocks red ingress, and Logistics 3 unlocks blue ingress
 - Additional lines have flat cost in v1
-- Global ingress upgrades scale by level
 - Expansion points awarded equal newly unlocked tiles
 - Expansion points spent on:
   - new resource lines
   - additional lines for unlocked resources
-  - global ingress tier upgrades
+  - additional ingress and egress lines
 
 ### Research
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The starting square size is a per-save map setting (`runtime-global` in Factorio
 
 Because square-expansion technologies are generated in the data stage, their precomputed costs use the default starting square size of `7` even if a save overrides the map setting. That mismatch is acceptable in practice because the ring costs quickly converge toward the same values as the square grows.
 
+`Ingress and egress line cost` is a per-save map setting. It defaults to `1000` expansion points for each additional owned ingress or egress line.
+
 `Enable logistic network automation` is also a per-save map setting. It is off by default, which blocks `active provider`, `buffer`, `requester`, and `storage` chests while still allowing passive providers, roboports, and logistic/construction bots.
 
 Square growth is now driven directly by research. Each completed level of `Square expansion` immediately expands the map by one ring and awards expansion points for the newly unlocked tiles.
@@ -22,6 +24,7 @@ Square growth is now driven directly by research. Each completed level of `Squar
 Research now includes custom expanding-square technologies:
 
 - `Square expansion` is a repeatable research line that starts with red science, then steps up to broader science-pack bands every 10 completed levels.
+- `Dual-lane ingress`, `Red ingress`, and `Blue ingress` are one-time researches unlocked after `Logistics`, `Logistics 2`, and `Logistics 3`. Each copies the science cost of the logistics technology that gates it.
 
 For manual testing, enable the per-player `Developer mode` runtime setting. That adds an `Expand square` button to the top-left UI plus a debug panel showing the current square-expansion progression state.
 

--- a/control.lua
+++ b/control.lua
@@ -34,6 +34,7 @@ script.on_configuration_changed(function()
   if storage.bootstrap then
     bootstrap_runtime.ensure_bootstrap_state_defaults()
     anchor_runtime.ensure_starter_anchor_state()
+    anchor_runtime.sync_ingress_tier_from_research(defs.get_player_force())
 
     if storage.bootstrap.square_size ~= defs.get_square_size() then
       bootstrap_runtime.notify_square_size_change_applies_to_new_saves()
@@ -103,16 +104,6 @@ script.on_event(defines.events.on_gui_click, function(event)
     return
   end
 
-  if event.element.name == "fes_shop_upgrade_ingress" then
-    if player then
-      anchor_runtime.purchase_ingress_tier_upgrade(player)
-      gui_runtime.refresh_shop_gui(player, anchor_runtime)
-      sync_all_runtime_guis()
-    end
-
-    return
-  end
-
   local resource = string.match(event.element.name, "^fes_shop_buy__(.+)$")
 
   if resource and player then
@@ -147,6 +138,11 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
     return
   end
 
+  if event.setting == defs.SETTING_LINE_PURCHASE_COST then
+    gui_runtime.sync_all_shop_guis(anchor_runtime)
+    return
+  end
+
   if event.setting == defs.SETTING_DEV_MODE then
     local player = game.get_player(event.player_index)
 
@@ -166,6 +162,10 @@ script.on_event(defines.events.on_research_finished, function(event)
   end
 
   if growth_runtime.handle_expansion_research_finished(research, bootstrap_runtime, gui_runtime, anchor_runtime) then
+    sync_all_runtime_guis()
+  end
+
+  if anchor_runtime.sync_ingress_tier_from_research(research.force) then
     sync_all_runtime_guis()
   end
 

--- a/data.lua
+++ b/data.lua
@@ -66,6 +66,36 @@ local square_expansion_research_bands = {
   }
 }
 
+local ingress_research_definitions = {
+  {
+    name = "fes-ingress-dual-lane",
+    icon = "__base__/graphics/icons/transport-belt.png",
+    prerequisite_technology_name = "logistics",
+    previous_ingress_technology_name = nil,
+    localised_name = {"technology-name.fes-ingress-dual-lane"},
+    localised_description = {"technology-description.fes-ingress-dual-lane"},
+    effect_description = {"technology-effect.fes-ingress-dual-lane"}
+  },
+  {
+    name = "fes-ingress-red",
+    icon = "__base__/graphics/icons/fast-transport-belt.png",
+    prerequisite_technology_name = "logistics-2",
+    previous_ingress_technology_name = "fes-ingress-dual-lane",
+    localised_name = {"technology-name.fes-ingress-red"},
+    localised_description = {"technology-description.fes-ingress-red"},
+    effect_description = {"technology-effect.fes-ingress-red"}
+  },
+  {
+    name = "fes-ingress-blue",
+    icon = "__base__/graphics/icons/express-transport-belt.png",
+    prerequisite_technology_name = "logistics-3",
+    previous_ingress_technology_name = "fes-ingress-red",
+    localised_name = {"technology-name.fes-ingress-blue"},
+    localised_description = {"technology-description.fes-ingress-blue"},
+    effect_description = {"technology-effect.fes-ingress-blue"}
+  }
+}
+
 local tips_and_tricks_items = {
   {
     name = "fes-mod",
@@ -293,6 +323,42 @@ local function build_square_expansion_technology(definition)
   }
 end
 
+local function copy_technology_unit(technology_name)
+  local technology = data.raw.technology[technology_name]
+
+  if not technology or not technology.unit then
+    error("Missing technology unit for " .. technology_name)
+  end
+
+  return table.deepcopy(technology.unit)
+end
+
+local function build_ingress_research_technology(definition)
+  local prerequisites = {definition.prerequisite_technology_name}
+
+  if definition.previous_ingress_technology_name then
+    prerequisites[#prerequisites + 1] = definition.previous_ingress_technology_name
+  end
+
+  return {
+    type = "technology",
+    name = definition.name,
+    localised_name = definition.localised_name,
+    localised_description = definition.localised_description,
+    icon = definition.icon,
+    icon_size = 64,
+    order = "c-b[" .. definition.name .. "]",
+    prerequisites = prerequisites,
+    unit = copy_technology_unit(definition.prerequisite_technology_name),
+    effects = {
+      {
+        type = "nothing",
+        effect_description = definition.effect_description
+      }
+    }
+  }
+end
+
 local function get_expansion_research_band(level)
   local selected_band = square_expansion_research_bands[1]
 
@@ -368,6 +434,10 @@ for level = 1, expansion_research.MAX_LEVEL do
     ingredients = band.ingredients,
     count = expansion_research.get_research_unit_count(starting_square_size, tiles_per_research, level)
   })
+end
+
+for _, definition in ipairs(ingress_research_definitions) do
+  prototypes[#prototypes + 1] = build_ingress_research_technology(definition)
 end
 
 for _, definition in ipairs(tips_and_tricks_items) do

--- a/lib/anchor_runtime.lua
+++ b/lib/anchor_runtime.lua
@@ -750,6 +750,25 @@ local function spend_expansion_points(amount)
   return true
 end
 
+function anchor_runtime.sync_ingress_tier_from_research(force)
+  local bootstrap = storage.bootstrap
+
+  if not bootstrap then
+    return false
+  end
+
+  local target_tier_level = defs.get_ingress_tier_level_for_force(force or defs.get_player_force())
+
+  if bootstrap.ingress_tier == target_tier_level then
+    return false
+  end
+
+  bootstrap.ingress_tier = target_tier_level
+  anchor_runtime.ensure_starter_anchors()
+
+  return true
+end
+
 local function get_shop_item_name(resource)
   local input_definition = defs.get_input_definition(resource)
 
@@ -770,6 +789,7 @@ function anchor_runtime.purchase_managed_line_for_resource(player, resource)
   local bootstrap = storage.bootstrap
   local definition, flow = defs.get_line_definition(resource)
   local item_name = get_shop_item_name(resource)
+  local line_purchase_cost = defs.get_line_purchase_cost()
 
   if not bootstrap or not definition or not item_name then
     return
@@ -789,9 +809,9 @@ function anchor_runtime.purchase_managed_line_for_resource(player, resource)
     return
   end
 
-  if not spend_expansion_points(defs.LINE_PURCHASE_COST) then
+  if not spend_expansion_points(line_purchase_cost) then
     if player and player.valid then
-      player.print({"message.fes-shop-not-enough-points", defs.LINE_PURCHASE_COST})
+      player.print({"message.fes-shop-not-enough-points", line_purchase_cost})
     end
 
     return
@@ -808,46 +828,7 @@ function anchor_runtime.purchase_managed_line_for_resource(player, resource)
     player.print({
       "message.fes-shop-purchased-line",
       {"item-name." .. item_name},
-      defs.LINE_PURCHASE_COST,
-      bootstrap.expansion_points
-    })
-  end
-end
-
-function anchor_runtime.purchase_ingress_tier_upgrade(player)
-  local bootstrap = storage.bootstrap
-  local next_tier_level = defs.get_next_ingress_tier_level()
-  local next_tier = next_tier_level and defs.get_ingress_tier_definition(next_tier_level) or nil
-  local upgrade_cost = defs.get_ingress_tier_upgrade_cost(next_tier_level)
-
-  if not bootstrap then
-    return
-  end
-
-  if not next_tier_level or not next_tier or not upgrade_cost then
-    if player and player.valid then
-      player.print({"message.fes-shop-ingress-max-tier"})
-    end
-
-    return
-  end
-
-  if not spend_expansion_points(upgrade_cost) then
-    if player and player.valid then
-      player.print({"message.fes-shop-not-enough-points", upgrade_cost})
-    end
-
-    return
-  end
-
-  bootstrap.ingress_tier = next_tier_level
-  anchor_runtime.ensure_starter_anchors()
-
-  if player and player.valid then
-    player.print({
-      "message.fes-shop-purchased-ingress-tier",
-      next_tier.label,
-      upgrade_cost,
+      line_purchase_cost,
       bootstrap.expansion_points
     })
   end

--- a/lib/gui_runtime.lua
+++ b/lib/gui_runtime.lua
@@ -224,28 +224,6 @@ local function build_shop_status_caption(resource, anchor_runtime)
   return "Not yet unlocked"
 end
 
-local function build_ingress_upgrade_caption(next_tier_level)
-  local next_tier = next_tier_level and defs.get_ingress_tier_definition(next_tier_level) or nil
-
-  if not next_tier then
-    return "Ingress tier maxed"
-  end
-
-  return "Upgrade to " .. next_tier.label
-end
-
-local function build_ingress_upgrade_status_caption()
-  local current_tier = defs.get_current_ingress_tier()
-  local next_tier_level = defs.get_next_ingress_tier_level()
-  local next_cost = defs.get_ingress_tier_upgrade_cost(next_tier_level)
-
-  if not next_tier_level or not next_cost then
-    return "Current: " .. current_tier.label .. " (maximum tier)"
-  end
-
-  return "Current: " .. current_tier.label .. " | Next cost: " .. next_cost
-end
-
 local function ensure_shop_frame(player)
   local frame = player.gui.left[defs.SHOP_FRAME_NAME]
 
@@ -280,27 +258,7 @@ function gui_runtime.refresh_shop_gui(player, anchor_runtime)
   })
   frame.add({
     type = "label",
-    caption = {"gui.fes-shop-line-cost", defs.LINE_PURCHASE_COST}
-  })
-  do
-    local flow = frame.add({
-      type = "flow",
-      direction = "horizontal"
-    })
-    local next_tier_level = defs.get_next_ingress_tier_level()
-    local next_upgrade_cost = defs.get_ingress_tier_upgrade_cost(next_tier_level)
-    local button = flow.add({
-      type = "button",
-      name = "fes_shop_upgrade_ingress",
-      caption = build_ingress_upgrade_caption(next_tier_level)
-    })
-
-    button.enabled = next_upgrade_cost ~= nil and (bootstrap.expansion_points or 0) >= next_upgrade_cost
-
-    flow.add({
-      type = "label",
-      caption = build_ingress_upgrade_status_caption()
-    })
+    caption = {"gui.fes-shop-line-cost", defs.get_line_purchase_cost()}
   end
 
   for _, definition in ipairs(defs.INPUT_DEFINITIONS) do
@@ -315,7 +273,7 @@ function gui_runtime.refresh_shop_gui(player, anchor_runtime)
       caption = {"gui.fes-shop-buy", {"item-name." .. defs.get_ingress_item_name(definition.resource)}}
     })
 
-    button.enabled = can_purchase and (bootstrap.expansion_points or 0) >= defs.LINE_PURCHASE_COST
+    button.enabled = can_purchase and (bootstrap.expansion_points or 0) >= defs.get_line_purchase_cost()
 
     flow.add({
       type = "label",
@@ -335,7 +293,7 @@ function gui_runtime.refresh_shop_gui(player, anchor_runtime)
       caption = {"gui.fes-shop-buy", {"item-name." .. defs.get_egress_item_name(definition.resource)}}
     })
 
-    button.enabled = can_purchase and (bootstrap.expansion_points or 0) >= defs.LINE_PURCHASE_COST
+    button.enabled = can_purchase and (bootstrap.expansion_points or 0) >= defs.get_line_purchase_cost()
 
     flow.add({
       type = "label",

--- a/lib/gui_runtime.lua
+++ b/lib/gui_runtime.lua
@@ -259,7 +259,7 @@ function gui_runtime.refresh_shop_gui(player, anchor_runtime)
   frame.add({
     type = "label",
     caption = {"gui.fes-shop-line-cost", defs.get_line_purchase_cost()}
-  end
+  })
 
   for _, definition in ipairs(defs.INPUT_DEFINITIONS) do
     local flow = frame.add({

--- a/lib/runtime_defs.lua
+++ b/lib/runtime_defs.lua
@@ -7,6 +7,7 @@ local runtime_defs = {}
 runtime_defs.SURFACE_NAME = "fes-bootstrap"
 runtime_defs.SETTING_STARTING_SQUARE_SIZE = "fes-starting-square-size"
 runtime_defs.SETTING_EXPANSION_TILES_PER_RESEARCH = "fes-expansion-tiles-per-research"
+runtime_defs.SETTING_LINE_PURCHASE_COST = "fes-line-purchase-cost"
 runtime_defs.SETTING_ENABLE_LOGISTIC_NETWORK_AUTOMATION = "fes-enable-logistic-network-automation"
 runtime_defs.SETTING_DEV_MODE = "fes-dev-mode"
 runtime_defs.SETTING_INGRESS_PLACEMENT_DEBUG = "fes-ingress-placement-debug"
@@ -23,8 +24,24 @@ runtime_defs.DEBUG_FRAME_NAME = "fes_debug_frame"
 runtime_defs.STATUS_FRAME_NAME = "fes_status_frame"
 runtime_defs.SHOP_BUTTON_NAME = "fes_shop_button"
 runtime_defs.SHOP_FRAME_NAME = "fes_shop_frame"
-runtime_defs.LINE_PURCHASE_COST = 12
 runtime_defs.MAX_INGRESS_TIER = 4
+runtime_defs.INGRESS_RESEARCH_DEFINITIONS = {
+  {
+    technology_name = "fes-ingress-dual-lane",
+    prerequisite_technology_name = "logistics",
+    tier_level = 2
+  },
+  {
+    technology_name = "fes-ingress-red",
+    prerequisite_technology_name = "logistics-2",
+    tier_level = 3
+  },
+  {
+    technology_name = "fes-ingress-blue",
+    prerequisite_technology_name = "logistics-3",
+    tier_level = 4
+  }
+}
 runtime_defs.EXPANSION_RESEARCH_LEVELS_PER_TIER = 10
 runtime_defs.MAX_EXPANSION_RESEARCH_LEVEL = expansion_research.MAX_LEVEL
 runtime_defs.EXPANSION_RESEARCH_BANDS = {
@@ -247,6 +264,10 @@ function runtime_defs.get_expansion_tiles_per_research()
   return settings.startup[runtime_defs.SETTING_EXPANSION_TILES_PER_RESEARCH].value
 end
 
+function runtime_defs.get_line_purchase_cost()
+  return settings.global[runtime_defs.SETTING_LINE_PURCHASE_COST].value
+end
+
 function runtime_defs.is_logistic_network_automation_enabled()
   return settings.global[runtime_defs.SETTING_ENABLE_LOGISTIC_NETWORK_AUTOMATION].value
 end
@@ -295,22 +316,22 @@ function runtime_defs.get_current_ingress_tier()
   return runtime_defs.get_ingress_tier_definition(runtime_defs.get_current_ingress_tier_level())
 end
 
-function runtime_defs.get_next_ingress_tier_level()
-  local next_level = runtime_defs.get_current_ingress_tier_level() + 1
+function runtime_defs.get_ingress_tier_level_for_force(force)
+  local tier_level = 1
 
-  if next_level > runtime_defs.MAX_INGRESS_TIER then
-    return nil
+  if not (force and force.valid and force.technologies) then
+    return tier_level
   end
 
-  return next_level
-end
+  for _, definition in ipairs(runtime_defs.INGRESS_RESEARCH_DEFINITIONS) do
+    local technology = force.technologies[definition.technology_name]
 
-function runtime_defs.get_ingress_tier_upgrade_cost(next_tier_level)
-  if not next_tier_level then
-    return nil
+    if technology and technology.researched and definition.tier_level > tier_level then
+      tier_level = definition.tier_level
+    end
   end
 
-  return runtime_defs.LINE_PURCHASE_COST * next_tier_level
+  return tier_level
 end
 
 function runtime_defs.get_next_expansion_tile_reward(square_size)

--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -1,6 +1,7 @@
 [mod-setting-name]
 fes-starting-square-size=Starting square size
 fes-expansion-tiles-per-research=Tiles per research pack
+fes-line-purchase-cost=Ingress and egress line cost
 fes-enable-logistic-network-automation=Enable logistic network automation
 fes-dev-mode=Developer mode
 fes-ingress-placement-debug=Ingress placement debug
@@ -8,6 +9,7 @@ fes-ingress-placement-debug=Ingress placement debug
 [mod-setting-description]
 fes-starting-square-size=Side length of the initial fixed bootstrap square for this save. Changing it after world creation does not resize the current square.
 fes-expansion-tiles-per-research=Target number of newly unlocked tiles funded by one science pack of each required type for square-expansion research. Lower values make each expansion cost more science. This is a startup setting and changing it requires reloading the game.
+fes-line-purchase-cost=Expansion-point cost of buying one additional ingress or egress line in this save.
 fes-enable-logistic-network-automation=Allows the late-game logistic chest network. When disabled, passive provider chests and logistic bots still work, but active provider, buffer, requester, and storage chests are blocked.
 fes-dev-mode=Shows developer-only controls for manual expansion and the expansion debug view during testing.
 fes-ingress-placement-debug=Prints ingress placement coordinates and edge-check details when you place an ingress item.
@@ -68,12 +70,21 @@ fes-egress-anchor=Owned egress anchor. Mine it to stash the line back into inven
 
 [technology-name]
 fes-square-expansion=Square expansion
+fes-ingress-dual-lane=Dual-lane ingress
+fes-ingress-red=Red ingress
+fes-ingress-blue=Blue ingress
 
 [technology-description]
 fes-square-expansion=Repeatable research that expands the square by one ring each time a level completes. Its cost scales with the next ring's tile reward and the map setting for tiles per research pack. It starts on red science and steps up to broader science-pack sets every 10 levels.
+fes-ingress-dual-lane=Upgrades every owned ingress line to use both yellow-belt lanes. Requires Logistics.
+fes-ingress-red=Upgrades every owned item ingress line to red-belt throughput and increases fluid ingress throughput to the matching tier. Requires Logistics 2.
+fes-ingress-blue=Upgrades every owned item ingress line to blue-belt throughput and increases fluid ingress throughput to the matching tier. Requires Logistics 3.
 
 [technology-effect]
 fes-square-expansion=Completing a level immediately expands the square by one ring.
+fes-ingress-dual-lane=All owned ingress lines upgrade to dual-lane yellow throughput.
+fes-ingress-red=All owned ingress lines upgrade to red-tier throughput.
+fes-ingress-blue=All owned ingress lines upgrade to blue-tier throughput.
 
 [message]
 fes-managed-line-invalid-surface=Managed lines can only be placed on the expanding-square surface.
@@ -85,8 +96,6 @@ fes-shop-not-enough-points=Not enough expansion points. Need __1__ points.
 fes-shop-purchased-line=Purchased __1__ for __2__ expansion points. Remaining points: __3__.
 fes-shop-prerequisite=You must unlock __1__ first.
 fes-shop-resource-unknown=That managed line resource is not available.
-fes-shop-ingress-max-tier=Ingress throughput is already at the maximum tier.
-fes-shop-purchased-ingress-tier=Upgraded ingress throughput to __1__ for __2__ expansion points. Remaining points: __3__.
 fes-expansion-research-completed=Square expansion research reached level __1__. Square size is now __2__x__2__.
 fes-logistic-network-disabled=__1__ is disabled by this map setting.
 
@@ -108,5 +117,5 @@ fes-overview=This mod replaces the normal open map with a managed square that st
 fes-expansion-research=Square growth is driven directly by science. Every completed level of square-expansion research immediately grows the map by one ring and unlocks the usual ring reward in expansion points.\n\nThe research cost is based on the number of tiles in the next ring and the map setting for tiles per research pack. When a level needs more science pack types, each required pack uses the same unit count. Every 10 completed levels it moves up to the next broader science-pack band.\n\nThe status panel shows completed expansion levels, the next science band, and the reward for the next ring.
 fes-ingress-lines=Resources do not come from patches inside the square. Instead, owned ingress anchors are placed on the current border and feed free raw resources inward from outside the map.\n\nThe starting lines are iron ore, copper ore, coal, stone, water, and wood. You can mine an owned ingress anchor to stash it, then place it again on another valid border tile for free. Item lines and fluid lines can share sides, but fluid anchors must keep at least one empty anchor tile between them.\n\nWhen the square expands, enabled ingress and egress lines move outward automatically and keep the connection going. Disabled or stashed lines remain owned but do not feed resources until placed again.
 fes-uranium-egress=Sulfuric acid egress is a later managed output line. Uranium ore ingress only runs while managed sulfuric acid egress is actually removing sulfuric acid from your factory.\n\nThe uranium allowance uses the same sulfuric-acid-to-ore relationship as vanilla uranium mining, including mining productivity. All placed sulfuric acid egress lines combine into one shared allowance pool, and all placed uranium ingress lines draw from that same shared pool. One sulfuric acid line does not grant full throughput to every uranium line.
-fes-research-and-rewards=Every expansion rewards expansion points equal to the number of newly unlocked tiles in that ring. Expansion points are spent in the ingress shop on additional lines and global ingress throughput upgrades.\n\nSquare-expansion research is the main progression loop for map growth, starting at red science and stepping up in science tiers over time.\n\nVanilla infinite research remains enabled after the normal rocket launch.
+fes-research-and-rewards=Every expansion rewards expansion points equal to the number of newly unlocked tiles in that ring. Expansion points are spent in the ingress shop on additional ingress and egress lines.\n\nIngress throughput upgrades come from dedicated research after Logistics, Logistics 2, and Logistics 3, matching those belt tiers.\n\nSquare-expansion research is the main progression loop for map growth, starting at red science and stepping up in science tiers over time.\n\nVanilla infinite research remains enabled after the normal rocket launch.
 fes-logistics-rule=Construction and deconstruction bots are allowed. Trains, handcrafting, and hand-feeding are also allowed.\n\nLogistic network automation is controlled by the map setting. When it is disabled, active provider chests, buffer chests, requester chests, and storage chests are blocked. Passive provider chests and logistic robots still work. When the setting is enabled, the logistic chest network behaves normally.

--- a/settings.lua
+++ b/settings.lua
@@ -18,24 +18,33 @@ data:extend({
     order = "b"
   },
   {
+    type = "int-setting",
+    name = "fes-line-purchase-cost",
+    setting_type = "runtime-global",
+    default_value = 1000,
+    minimum_value = 1,
+    maximum_value = 1000000,
+    order = "c"
+  },
+  {
     type = "bool-setting",
     name = "fes-enable-logistic-network-automation",
     setting_type = "runtime-global",
     default_value = false,
-    order = "c"
+    order = "d"
   },
   {
     type = "bool-setting",
     name = "fes-dev-mode",
     setting_type = "runtime-per-user",
     default_value = false,
-    order = "d"
+    order = "e"
   },
   {
     type = "bool-setting",
     name = "fes-ingress-placement-debug",
     setting_type = "runtime-per-user",
     default_value = false,
-    order = "e"
+    order = "f"
   }
 })


### PR DESCRIPTION
## Summary
- move ingress throughput progression from the expansion-point shop into dedicated research after Logistics, Logistics 2, and Logistics 3
- remove ingress tier purchasing from the shop and make line purchases use a runtime-global map setting that defaults to 1000 expansion points
- update locale and docs to describe the new progression and map setting

## Verification
- make build
- direct lua and luac checks were not available in this environment because those executables are not installed

## Notes
- on configuration change, existing saves now resync ingress tier from completed ingress research