### PR TITLE
Move background tile selection to map settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Because square-expansion technologies are generated in the data stage, their pre
 
 `Enable logistic network automation` is also a per-save map setting. It is off by default, which blocks `active provider`, `buffer`, `requester`, and `storage` chests while still allowing passive providers, roboports, and logistic/construction bots.
 
+`Background tile` is a per-save map setting under `Mod settings -> Map`. It repaints the square floor uniformly, with curated dry tiles plus lab tiles and a special checkerboard option. Water, concrete, and stone-brick style tiles are intentionally excluded.
+
 Square growth is now driven directly by research. Each completed level of `Square expansion` immediately expands the map by one ring and awards expansion points for the newly unlocked tiles.
 
 Research now includes custom expanding-square technologies:
@@ -27,6 +29,8 @@ Research now includes custom expanding-square technologies:
 - `Dual-lane ingress`, `Red ingress`, and `Blue ingress` are one-time researches unlocked after `Logistics`, `Logistics 2`, and `Logistics 3`. Each copies the science cost of the logistics technology that gates it.
 
 For manual testing, enable the per-player `Developer mode` runtime setting. That adds an `Expand square` button to the top-left UI plus a debug panel showing the current square-expansion progression state.
+
+Issue `#18` was resolved by `PR #52`, which fixed the border/background rendering regressions that prompted the earlier experiments here.
 
 `make install` builds the zip and copies it into your local Factorio mods directory. By default the install script auto-detects:
 

--- a/control.lua
+++ b/control.lua
@@ -143,6 +143,18 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
     return
   end
 
+  if event.setting == defs.SETTING_BACKGROUND_TILE then
+    local surface = storage.bootstrap and game.surfaces[storage.bootstrap.surface_name]
+
+    if surface and storage.bootstrap then
+      bootstrap_runtime.refresh_managed_surface_tiles(surface, storage.bootstrap.square_size, storage.bootstrap.surface_size)
+    end
+
+    gui_runtime.refresh_all_status_guis()
+    gui_runtime.refresh_all_debug_guis()
+    return
+  end
+
   if event.setting == defs.SETTING_DEV_MODE then
     local player = game.get_player(event.player_index)
 

--- a/lib/bootstrap_runtime.lua
+++ b/lib/bootstrap_runtime.lua
@@ -4,7 +4,7 @@ local bootstrap_runtime = {}
 local ensure_surface_dimensions
 
 local function get_target_surface_size(square_size, expansions_completed)
-  return square_size + 2
+  return defs.get_surface_size(square_size)
 end
 
 local function get_edge_positions(bounds, side)

--- a/lib/gui_runtime.lua
+++ b/lib/gui_runtime.lua
@@ -80,6 +80,7 @@ local function build_status_lines()
   local next_band = defs.get_expansion_research_band_for_level(next_level)
 
   lines[#lines + 1] = "Square: " .. bootstrap.square_size .. "x" .. bootstrap.square_size
+  lines[#lines + 1] = "Background tile: " .. defs.get_background_tile_name()
   lines[#lines + 1] = "Logistics setting: "
     .. (defs.is_logistic_network_automation_enabled() and "enabled" or "disabled")
   lines[#lines + 1] = "Expansion research: " .. completed_levels .. " levels completed"

--- a/lib/runtime_defs.lua
+++ b/lib/runtime_defs.lua
@@ -9,10 +9,17 @@ runtime_defs.SETTING_STARTING_SQUARE_SIZE = "fes-starting-square-size"
 runtime_defs.SETTING_EXPANSION_TILES_PER_RESEARCH = "fes-expansion-tiles-per-research"
 runtime_defs.SETTING_LINE_PURCHASE_COST = "fes-line-purchase-cost"
 runtime_defs.SETTING_ENABLE_LOGISTIC_NETWORK_AUTOMATION = "fes-enable-logistic-network-automation"
+runtime_defs.SETTING_BACKGROUND_TILE = "fes-background-tile"
 runtime_defs.SETTING_DEV_MODE = "fes-dev-mode"
 runtime_defs.SETTING_INGRESS_PLACEMENT_DEBUG = "fes-ingress-placement-debug"
 runtime_defs.FLOOR_TILE_NAME = "grass-1"
 runtime_defs.VOID_TILE_NAME = "out-of-map"
+runtime_defs.DEFAULT_BACKGROUND_TILE_NAME = "grass-1"
+runtime_defs.CHECKERBOARD_BACKGROUND_TILE_NAME = "checkerboard"
+runtime_defs.CHECKERBOARD_TILE_NAMES = {
+  even = "lab-dark-1",
+  odd = "lab-dark-2"
+}
 runtime_defs.CHART_MARGIN = 1
 runtime_defs.ITEM_ANCHOR_INTERVAL_TICKS = 8
 runtime_defs.ANCHOR_SLOT_PROXY_NAME = "fes-anchor-slot-proxy"
@@ -280,6 +287,16 @@ function runtime_defs.get_surface_size(square_size)
   return bootstrap_layout.get_surface_size(square_size, runtime_defs.STARTER_ANCHOR_OUTER_RING_WIDTH)
 end
 
+function runtime_defs.get_background_tile_name()
+  local background_tile_setting = settings.global[runtime_defs.SETTING_BACKGROUND_TILE]
+
+  if background_tile_setting and background_tile_setting.value then
+    return background_tile_setting.value
+  end
+
+  return runtime_defs.DEFAULT_BACKGROUND_TILE_NAME
+end
+
 function runtime_defs.get_anchor_bounds(square_size)
   return bootstrap_layout.get_anchor_bounds(square_size)
 end
@@ -392,10 +409,19 @@ function runtime_defs.is_anchor_ring_position(square_size, position)
 end
 
 function runtime_defs.get_managed_tile_name(square_size, surface_size, position)
+  local background_tile_name = runtime_defs.get_background_tile_name()
+
+  if background_tile_name == runtime_defs.CHECKERBOARD_BACKGROUND_TILE_NAME
+    and bootstrap_layout.is_inside_bounds(bootstrap_layout.get_square_bounds(square_size), position) then
+    local parity = math.abs(position.x + position.y) % 2 == 0 and "even" or "odd"
+
+    return runtime_defs.CHECKERBOARD_TILE_NAMES[parity]
+  end
+
   return bootstrap_layout.get_managed_tile_name(
     square_size,
     surface_size,
-    runtime_defs.FLOOR_TILE_NAME,
+    background_tile_name,
     runtime_defs.VOID_TILE_NAME,
     position
   )

--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -3,14 +3,43 @@ fes-starting-square-size=Starting square size
 fes-expansion-tiles-per-research=Tiles per research pack
 fes-line-purchase-cost=Ingress and egress line cost
 fes-enable-logistic-network-automation=Enable logistic network automation
+fes-background-tile=Background tile
 fes-dev-mode=Developer mode
 fes-ingress-placement-debug=Ingress placement debug
+
+[string-mod-setting]
+fes-background-tile-grass-1=[img=tile/grass-1] Grass 1
+fes-background-tile-grass-2=[img=tile/grass-2] Grass 2
+fes-background-tile-grass-3=[img=tile/grass-3] Grass 3
+fes-background-tile-grass-4=[img=tile/grass-4] Grass 4
+fes-background-tile-dirt-1=[img=tile/dirt-1] Dirt 1
+fes-background-tile-dirt-2=[img=tile/dirt-2] Dirt 2
+fes-background-tile-dirt-3=[img=tile/dirt-3] Dirt 3
+fes-background-tile-dirt-4=[img=tile/dirt-4] Dirt 4
+fes-background-tile-dirt-5=[img=tile/dirt-5] Dirt 5
+fes-background-tile-dirt-6=[img=tile/dirt-6] Dirt 6
+fes-background-tile-dirt-7=[img=tile/dirt-7] Dirt 7
+fes-background-tile-dry-dirt=[img=tile/dry-dirt] Dry dirt
+fes-background-tile-sand-1=[img=tile/sand-1] Sand 1
+fes-background-tile-sand-2=[img=tile/sand-2] Sand 2
+fes-background-tile-sand-3=[img=tile/sand-3] Sand 3
+fes-background-tile-red-desert-0=[img=tile/red-desert-0] Red desert 0
+fes-background-tile-red-desert-1=[img=tile/red-desert-1] Red desert 1
+fes-background-tile-red-desert-2=[img=tile/red-desert-2] Red desert 2
+fes-background-tile-red-desert-3=[img=tile/red-desert-3] Red desert 3
+fes-background-tile-landfill=[img=tile/landfill] Landfill
+fes-background-tile-lab-dark-1=[img=tile/lab-dark-1] Lab dark 1
+fes-background-tile-lab-dark-2=[img=tile/lab-dark-2] Lab dark 2
+fes-background-tile-lab-white=[img=tile/lab-white] Lab white
+fes-background-tile-nuclear-ground=[img=tile/nuclear-ground] Nuclear ground
+fes-background-tile-checkerboard=[img=tile/lab-dark-1][img=tile/lab-dark-2] Checkerboard
 
 [mod-setting-description]
 fes-starting-square-size=Side length of the initial fixed bootstrap square for this save. Changing it after world creation does not resize the current square.
 fes-expansion-tiles-per-research=Target number of newly unlocked tiles funded by one science pack of each required type for square-expansion research. Lower values make each expansion cost more science. This is a startup setting and changing it requires reloading the game.
 fes-line-purchase-cost=Expansion-point cost of buying one additional ingress or egress line in this save.
 fes-enable-logistic-network-automation=Allows the late-game logistic chest network. When disabled, passive provider chests and logistic bots still work, but active provider, buffer, requester, and storage chests are blocked.
+fes-background-tile=Uniform tile used for the managed square floor. This appears under Mod settings -> Map. Water, concrete, and stone brick style tiles are intentionally excluded. Checkerboard alternates lab-dark-1 and lab-dark-2.
 fes-dev-mode=Shows developer-only controls for manual expansion and the expansion debug view during testing.
 fes-ingress-placement-debug=Prints ingress placement coordinates and edge-check details when you place an ingress item.
 

--- a/settings.lua
+++ b/settings.lua
@@ -34,17 +34,51 @@ data:extend({
     order = "d"
   },
   {
+    type = "string-setting",
+    name = "fes-background-tile",
+    setting_type = "runtime-global",
+    default_value = "grass-1",
+    allowed_values = {
+      "grass-1",
+      "grass-2",
+      "grass-3",
+      "grass-4",
+      "dirt-1",
+      "dirt-2",
+      "dirt-3",
+      "dirt-4",
+      "dirt-5",
+      "dirt-6",
+      "dirt-7",
+      "dry-dirt",
+      "sand-1",
+      "sand-2",
+      "sand-3",
+      "red-desert-0",
+      "red-desert-1",
+      "red-desert-2",
+      "red-desert-3",
+      "landfill",
+      "lab-dark-1",
+      "lab-dark-2",
+      "lab-white",
+      "nuclear-ground",
+      "checkerboard"
+    },
+    order = "e"
+  },
+  {
     type = "bool-setting",
     name = "fes-dev-mode",
     setting_type = "runtime-per-user",
     default_value = false,
-    order = "e"
+    order = "f"
   },
   {
     type = "bool-setting",
     name = "fes-ingress-placement-debug",
     setting_type = "runtime-per-user",
     default_value = false,
-    order = "f"
+    order = "g"
   }
 })

--- a/tests/bootstrap_layout_spec.lua
+++ b/tests/bootstrap_layout_spec.lua
@@ -35,14 +35,14 @@ run_test("anchor ring tiles stay out of map", function()
   )
 end)
 
-run_test("playable square stays walkable floor", function()
+run_test("playable square uses the selected uniform tile", function()
   local square_size = 12
   local surface_size = bootstrap_layout.get_surface_size(square_size, 1)
 
   assert_equal(
-    bootstrap_layout.get_managed_tile_name(square_size, surface_size, "grass-1", "out-of-map", {x = 0, y = 0}),
-    "grass-1",
-    "the playable square should keep floor tiles"
+    bootstrap_layout.get_managed_tile_name(square_size, surface_size, "sand-3", "out-of-map", {x = 0, y = 0}),
+    "sand-3",
+    "the playable square should use the configured tile"
   )
 end)
 

--- a/tests/runtime_defs_spec.lua
+++ b/tests/runtime_defs_spec.lua
@@ -1,0 +1,58 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+defines = {
+  direction = {
+    south = 1,
+    west = 2,
+    north = 3,
+    east = 4
+  }
+}
+
+settings = {
+  global = {
+    ["fes-background-tile"] = {
+      value = "checkerboard"
+    }
+  }
+}
+
+local runtime_defs = require("lib.runtime_defs")
+
+local function assert_equal(actual, expected, message)
+  if actual ~= expected then
+    error((message or "values differ") .. "\nexpected: " .. tostring(expected) .. "\nactual: " .. tostring(actual))
+  end
+end
+
+local function run_test(name, fn)
+  local ok, err = pcall(fn)
+
+  if not ok then
+    io.stderr:write("FAIL " .. name .. "\n" .. err .. "\n")
+    os.exit(1)
+  end
+
+  io.stdout:write("PASS " .. name .. "\n")
+end
+
+run_test("checkerboard alternates lab floor tiles inside the square", function()
+  assert_equal(
+    runtime_defs.get_managed_tile_name(7, 9, {x = 0, y = 0}),
+    "lab-dark-1",
+    "even-parity tiles should use the first checkerboard tile"
+  )
+  assert_equal(
+    runtime_defs.get_managed_tile_name(7, 9, {x = 1, y = 0}),
+    "lab-dark-2",
+    "odd-parity tiles should use the second checkerboard tile"
+  )
+end)
+
+run_test("checkerboard still keeps the border out of map", function()
+  assert_equal(
+    runtime_defs.get_managed_tile_name(7, 9, {x = 0, y = -4}),
+    "out-of-map",
+    "checkerboard should not replace the managed void border"
+  )
+end)


### PR DESCRIPTION
## Summary
- move background tile selection from the custom in-game UI to Mod settings -> Map
- restrict the allowed background tiles to the curated non-water, non-concrete, non-stone-brick set and add a checkerboard option
- add regression coverage for checkerboard tile painting and document that issue #18 was fixed by PR #52

## Verification
- /opt/homebrew/bin/luajit tests/bootstrap_layout_spec.lua
- /opt/homebrew/bin/luajit tests/expansion_research_spec.lua
- /opt/homebrew/bin/luajit tests/item_ingress_spec.lua
- /opt/homebrew/bin/luajit tests/resource_balance_spec.lua
- /opt/homebrew/bin/luajit tests/runtime_defs_spec.lua
- make build

Closes #51
Closes #18

Note: issue #18 was fixed by PR #52; this PR documents that and closes the still-open issue.