### PR TITLE
Polish starter anchor visuals

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -16,9 +16,9 @@ local egress_resources = {
 }
 
 local item_ingress_belt_tiers = {
-  {key = "yellow", prototype_name = "transport-belt"},
-  {key = "red", prototype_name = "fast-transport-belt"},
-  {key = "blue", prototype_name = "express-transport-belt"}
+  {key = "yellow", prototype_name = "underground-belt"},
+  {key = "red", prototype_name = "fast-underground-belt"},
+  {key = "blue", prototype_name = "express-underground-belt"}
 }
 
 local square_expansion_research_bands = {
@@ -215,8 +215,8 @@ end
 
 local function build_ingress_entity(definition, belt_tier_key, belt_prototype_name)
   local source = definition.kind == "fluid"
-    and table.deepcopy(data.raw.pipe.pipe)
-    or table.deepcopy(data.raw["transport-belt"][belt_prototype_name or "transport-belt"])
+    and table.deepcopy(data.raw["offshore-pump"]["offshore-pump"])
+    or table.deepcopy(data.raw["underground-belt"][belt_prototype_name or "underground-belt"])
   local item_name = ingress_item_name(definition.resource)
 
   source.name = ingress_entity_name(definition.resource, belt_tier_key)
@@ -283,7 +283,7 @@ local function build_anchor_place_input()
 end
 
 local function build_egress_entity(definition)
-  local source = table.deepcopy(data.raw.pipe.pipe)
+  local source = table.deepcopy(data.raw["offshore-pump"]["offshore-pump"])
   local item_name = egress_item_name(definition.resource)
 
   source.name = egress_entity_name(definition.resource)

--- a/lib/anchor_runtime.lua
+++ b/lib/anchor_runtime.lua
@@ -60,6 +60,14 @@ local function configure_source_anchor_entity(entity, direction)
   entity.operable = false
 end
 
+local function get_required_underground_belt_type(anchor)
+  if anchor and anchor.flow == "ingress" and anchor.kind == "item" then
+    return "output"
+  end
+
+  return nil
+end
+
 local function is_ingress_entity_name(entity_name)
   for _, definition in ipairs(defs.INPUT_DEFINITIONS) do
     if defs.is_ingress_entity_name_for_resource(definition.resource, entity_name) then
@@ -177,7 +185,7 @@ local function assign_anchor_position(anchor, side, position)
 
   anchor.position = position
   anchor.side = side
-  anchor.direction = defs.DIRECTION_BY_SIDE[side]
+  anchor.direction = defs.get_anchor_direction_for_side(anchor.flow, anchor.kind, side)
   anchor.entity_name = defs.get_anchor_entity_name_for_current_tier(anchor)
   anchor.entity = nil
 
@@ -258,8 +266,12 @@ local function ensure_anchor_entity(surface, anchor)
   local entity = anchor.entity
 
   if entity and entity.valid and entity.name == anchor.entity_name then
-    configure_source_anchor_entity(entity, anchor.direction)
-    return entity
+    local required_belt_type = get_required_underground_belt_type(anchor)
+
+    if not required_belt_type or entity.belt_to_ground_type == required_belt_type then
+      configure_source_anchor_entity(entity, anchor.direction)
+      return entity
+    end
   end
 
   if entity and entity.valid then
@@ -272,16 +284,23 @@ local function ensure_anchor_entity(surface, anchor)
   entity = find_entity_at_position(surface, anchor.entity_name, anchor.position)
 
   if entity and entity.valid then
-    anchor.entity = entity
-    configure_source_anchor_entity(entity, anchor.direction)
-    return entity
+    local required_belt_type = get_required_underground_belt_type(anchor)
+
+    if not required_belt_type or entity.belt_to_ground_type == required_belt_type then
+      anchor.entity = entity
+      configure_source_anchor_entity(entity, anchor.direction)
+      return entity
+    end
+
+    entity.destroy({raise_destroy = false})
   end
 
   entity = surface.create_entity({
     name = anchor.entity_name,
     position = anchor.position,
     direction = anchor.direction,
-    force = game.forces.player
+    force = game.forces.player,
+    type = get_required_underground_belt_type(anchor)
   })
 
   if entity then
@@ -359,7 +378,7 @@ local function migrate_anchor_to_anchor_ring(square_size, anchor)
   end
 
   anchor.position = defs.move_position(anchor.position, anchor.side, 1)
-  anchor.direction = defs.DIRECTION_BY_SIDE[anchor.side]
+  anchor.direction = defs.get_anchor_direction_for_side(anchor.flow, anchor.kind, anchor.side)
   anchor.entity = nil
 end
 
@@ -376,6 +395,7 @@ function anchor_runtime.ensure_starter_anchor_state()
     for _, anchor in ipairs(migrated_anchors) do
       anchor.flow = anchor.flow or "ingress"
       anchor.item_progress = anchor.item_progress or {0, 0}
+      anchor.direction = anchor.side and defs.get_anchor_direction_for_side(anchor.flow, anchor.kind, anchor.side) or nil
       anchor.item_name = anchor.item_name or (
         anchor.flow == "egress"
           and defs.get_egress_item_name(anchor.resource)
@@ -404,6 +424,7 @@ function anchor_runtime.ensure_starter_anchor_state()
   for _, anchor in ipairs(storage.starter_anchors.anchors) do
     anchor.flow = anchor.flow or "ingress"
     anchor.item_progress = anchor.item_progress or {0, 0}
+    anchor.direction = anchor.side and defs.get_anchor_direction_for_side(anchor.flow, anchor.kind, anchor.side) or nil
     migrate_anchor_to_anchor_ring(bootstrap.square_size, anchor)
   end
 

--- a/lib/bootstrap_runtime.lua
+++ b/lib/bootstrap_runtime.lua
@@ -318,7 +318,7 @@ local function move_starter_anchors_outward()
   for _, anchor in ipairs(starter_anchors.anchors) do
     if anchor.position and anchor.side then
       anchor.position = defs.move_position(anchor.position, anchor.side, 1)
-      anchor.direction = defs.DIRECTION_BY_SIDE[anchor.side]
+      anchor.direction = defs.get_anchor_direction_for_side(anchor.flow, anchor.kind, anchor.side)
       anchor.entity = nil
     end
   end
@@ -380,7 +380,7 @@ local function leave_trailing_ingress_stub(surface, anchor)
   surface.create_entity({
     name = trailing_entity_name,
     position = anchor.position,
-    direction = anchor.direction,
+    direction = anchor.kind == "item" and defs.DIRECTION_BY_SIDE[anchor.side] or anchor.direction,
     force = game.forces.player
   })
 end

--- a/lib/runtime_defs.lua
+++ b/lib/runtime_defs.lua
@@ -25,7 +25,7 @@ runtime_defs.ITEM_ANCHOR_INTERVAL_TICKS = 8
 runtime_defs.ANCHOR_SLOT_PROXY_NAME = "fes-anchor-slot-proxy"
 runtime_defs.PLACE_MANAGED_ANCHOR_INPUT_NAME = "fes-place-managed-anchor"
 runtime_defs.STARTER_ANCHOR_OUTER_RING_WIDTH = 1
-runtime_defs.STARTER_ANCHOR_LAYOUT_VERSION = 8
+runtime_defs.STARTER_ANCHOR_LAYOUT_VERSION = 12
 runtime_defs.DEV_EXPAND_BUTTON_NAME = "fes_dev_expand_button"
 runtime_defs.DEBUG_FRAME_NAME = "fes_debug_frame"
 runtime_defs.STATUS_FRAME_NAME = "fes_status_frame"
@@ -116,6 +116,12 @@ runtime_defs.DIRECTION_BY_SIDE = {
   east = defines.direction.west,
   south = defines.direction.north,
   west = defines.direction.east
+}
+runtime_defs.REVERSED_DIRECTION_BY_SIDE = {
+  north = defines.direction.north,
+  east = defines.direction.east,
+  south = defines.direction.south,
+  west = defines.direction.west
 }
 runtime_defs.OFFSET_BY_SIDE = {
   north = {x = 0, y = -1},
@@ -251,7 +257,7 @@ function runtime_defs.create_managed_anchor(definition, flow, side, position)
     kind = definition.kind,
     flow = flow,
     side = side,
-    direction = side and runtime_defs.DIRECTION_BY_SIDE[side] or nil,
+    direction = side and runtime_defs.get_anchor_direction_for_side(flow, definition.kind, side) or nil,
     position = position,
     item_name = flow == "egress"
       and runtime_defs.get_egress_item_name(definition.resource)
@@ -261,6 +267,18 @@ function runtime_defs.create_managed_anchor(definition, flow, side, position)
       or runtime_defs.get_ingress_entity_name(definition.resource),
     item_progress = {0, 0}
   }
+end
+
+function runtime_defs.get_anchor_direction_for_side(flow, kind, side)
+  if not side then
+    return nil
+  end
+
+  if kind == "fluid" then
+    return runtime_defs.REVERSED_DIRECTION_BY_SIDE[side]
+  end
+
+  return runtime_defs.DIRECTION_BY_SIDE[side]
 end
 
 function runtime_defs.get_square_size()


### PR DESCRIPTION
## Summary
- switch starter item anchors to underground-belt visuals and fluid anchors to offshore-pump visuals
- create managed underground anchors as output belts at runtime and refresh mismatched existing anchors
- keep anchor-facing and expansion stub direction aligned with the intended inward flow

## Testing
- in-game verification by user
- no automated tests run in this environment

Closes #19