### PR TITLE
Add make test target for the Lua spec suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,21 @@
 SHELL := /bin/sh
 
-.PHONY: build install
+LUA ?= $(shell command -v luajit 2>/dev/null || command -v lua 2>/dev/null)
+
+.PHONY: build install test
 
 build:
 	./scripts/build-mod.sh
 
 install:
 	./scripts/install-mod.sh
+
+test:
+	@if [ -z "$(LUA)" ]; then \
+		echo "error: expected luajit or lua in PATH" >&2; \
+		exit 1; \
+	fi
+	@for spec in tests/*_spec.lua; do \
+		echo "==> $$spec"; \
+		"$(LUA)" "$$spec" || exit 1; \
+	done

--- a/README.md
+++ b/README.md
@@ -5,9 +5,18 @@ Local development commands:
 ```sh
 make build
 make install
+make test
 ```
 
 `make build` creates a versioned Factorio mod zip in `./build/` using the `name` and `version` from `info.json`.
+
+`make test` runs every Lua spec in `tests/*_spec.lua` and stops on the first failure. It requires either `luajit` or `lua` to be available on `PATH`; the target prefers `luajit` when both are installed.
+
+If you need to force a specific runtime, override `LUA` directly:
+
+```sh
+make test LUA=lua
+```
 
 The starting square size is a per-save map setting (`runtime-global` in Factorio terms). Set it when creating a run. Changing it after the bootstrap surface already exists does not resize the current save.
 


### PR DESCRIPTION
## Summary
- add a root `make test` target that runs all Lua specs with `luajit`/`lua`
- fail loudly when no supported runtime is installed
- document the test command and runtime override in the README

Closes #54

## Testing
- make test