### PR TITLE
Bundle sulfuric acid egress with uranium ingress

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -283,7 +283,7 @@ local function build_anchor_place_input()
 end
 
 local function build_egress_entity(definition)
-  local source = table.deepcopy(data.raw["offshore-pump"]["offshore-pump"])
+  local source = table.deepcopy(data.raw["pipe-to-ground"]["pipe-to-ground"])
   local item_name = egress_item_name(definition.resource)
 
   source.name = egress_entity_name(definition.resource)

--- a/lib/anchor_runtime.lua
+++ b/lib/anchor_runtime.lua
@@ -806,6 +806,28 @@ local function get_shop_item_name(resource)
   return nil
 end
 
+local function grant_managed_line(player, bootstrap, definition, flow, item_name, purchase_message)
+  if not (bootstrap and definition and flow and item_name) then
+    return false
+  end
+
+  storage.starter_anchors = storage.starter_anchors or {
+    layout_version = defs.STARTER_ANCHOR_LAYOUT_VERSION,
+    anchors = bootstrap_runtime.build_starter_anchor_layout(bootstrap.square_size)
+  }
+  storage.starter_anchors.anchors[#storage.starter_anchors.anchors + 1] = defs.create_managed_anchor(definition, flow, nil, nil)
+
+  if player and player.valid then
+    player_insert_or_spill(player, item_name)
+
+    if purchase_message then
+      player.print(purchase_message)
+    end
+  end
+
+  return true
+end
+
 function anchor_runtime.purchase_managed_line_for_resource(player, resource)
   local bootstrap = storage.bootstrap
   local definition, flow = defs.get_line_definition(resource)
@@ -838,20 +860,18 @@ function anchor_runtime.purchase_managed_line_for_resource(player, resource)
     return
   end
 
-  storage.starter_anchors = storage.starter_anchors or {
-    layout_version = defs.STARTER_ANCHOR_LAYOUT_VERSION,
-    anchors = bootstrap_runtime.build_starter_anchor_layout(bootstrap.square_size)
-  }
-  storage.starter_anchors.anchors[#storage.starter_anchors.anchors + 1] = defs.create_managed_anchor(definition, flow, nil, nil)
+  grant_managed_line(player, bootstrap, definition, flow, item_name, {
+    "message.fes-shop-purchased-line",
+    {"item-name." .. item_name},
+    line_purchase_cost,
+    bootstrap.expansion_points
+  })
 
-  if player and player.valid then
-    player_insert_or_spill(player, item_name)
-    player.print({
-      "message.fes-shop-purchased-line",
-      {"item-name." .. item_name},
-      line_purchase_cost,
-      bootstrap.expansion_points
-    })
+  if resource == "uranium-ore" and not anchor_runtime.is_resource_unlocked("sulfuric-acid") then
+    local sulfuric_acid_definition = defs.get_output_definition("sulfuric-acid")
+    local sulfuric_acid_item_name = defs.get_egress_item_name("sulfuric-acid")
+
+    grant_managed_line(player, bootstrap, sulfuric_acid_definition, "egress", sulfuric_acid_item_name)
   end
 end
 

--- a/lib/runtime_defs.lua
+++ b/lib/runtime_defs.lua
@@ -275,6 +275,10 @@ function runtime_defs.get_anchor_direction_for_side(flow, kind, side)
   end
 
   if kind == "fluid" then
+    if flow == "egress" then
+      return runtime_defs.DIRECTION_BY_SIDE[side]
+    end
+
     return runtime_defs.REVERSED_DIRECTION_BY_SIDE[side]
   end
 

--- a/tests/anchor_runtime_spec.lua
+++ b/tests/anchor_runtime_spec.lua
@@ -1,0 +1,122 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+defines = {
+  direction = {
+    south = 1,
+    west = 2,
+    north = 3,
+    east = 4
+  }
+}
+
+settings = {
+  global = {
+    ["fes-background-tile"] = {
+      value = "grass-1"
+    },
+    ["fes-line-purchase-cost"] = {
+      value = 1000
+    }
+  }
+}
+
+storage = {
+  bootstrap = {
+    square_size = 12,
+    expansion_points = 5000
+  }
+}
+
+local anchor_runtime = require("lib.anchor_runtime")
+local runtime_defs = require("lib.runtime_defs")
+
+local function assert_equal(actual, expected, message)
+  if actual ~= expected then
+    error((message or "values differ") .. "\nexpected: " .. tostring(expected) .. "\nactual: " .. tostring(actual))
+  end
+end
+
+local function run_test(name, fn)
+  local ok, err = pcall(fn)
+
+  if not ok then
+    io.stderr:write("FAIL " .. name .. "\n" .. err .. "\n")
+    os.exit(1)
+  end
+
+  io.stdout:write("PASS " .. name .. "\n")
+end
+
+local function build_player()
+  local inventory = {}
+  local messages = {}
+
+  return {
+    valid = true,
+    force = {},
+    position = {x = 0, y = 0},
+    surface = {
+      spill_item_stack = function(_, _, _, _, _)
+      end
+    },
+    insert = function(stack)
+      inventory[#inventory + 1] = stack.name
+      return stack.count
+    end,
+    print = function(message)
+      messages[#messages + 1] = message
+    end,
+    get_inventory_names = function()
+      return inventory
+    end,
+    get_messages = function()
+      return messages
+    end
+  }
+end
+
+run_test("uranium purchase also grants one sulfuric acid egress line", function()
+  storage.bootstrap.expansion_points = 5000
+
+  local player = build_player()
+  local crude_oil_definition = runtime_defs.get_input_definition("crude-oil")
+
+  storage.starter_anchors = {
+    layout_version = runtime_defs.STARTER_ANCHOR_LAYOUT_VERSION,
+    anchors = {
+      runtime_defs.create_managed_anchor(crude_oil_definition, "ingress", nil, nil)
+    }
+  }
+
+  anchor_runtime.purchase_managed_line_for_resource(player, "uranium-ore")
+
+  assert_equal(storage.bootstrap.expansion_points, 4000, "uranium purchase should only spend one line cost")
+  assert_equal(anchor_runtime.get_owned_line_counts("uranium-ore").owned, 1, "uranium should be owned after purchase")
+  assert_equal(
+    anchor_runtime.get_owned_line_counts("sulfuric-acid").owned,
+    1,
+    "first uranium purchase should also grant sulfuric acid egress ownership"
+  )
+
+  local inventory = player.get_inventory_names()
+
+  assert_equal(inventory[1], runtime_defs.get_ingress_item_name("uranium-ore"), "player should receive the uranium ingress item")
+  assert_equal(
+    inventory[2],
+    runtime_defs.get_egress_item_name("sulfuric-acid"),
+    "player should also receive the sulfuric acid egress item"
+  )
+end)
+
+run_test("fluid egress faces inward on the managed border", function()
+  assert_equal(
+    runtime_defs.get_anchor_direction_for_side("egress", "fluid", "north"),
+    defines.direction.south,
+    "north-side fluid egress should face inward"
+  )
+  assert_equal(
+    runtime_defs.get_anchor_direction_for_side("egress", "fluid", "west"),
+    defines.direction.east,
+    "west-side fluid egress should face inward"
+  )
+end)


### PR DESCRIPTION
## Summary
- grant the first sulfuric acid egress line automatically when uranium ingress is purchased
- switch sulfuric acid egress anchors to pipe-to-ground entities
- add regression coverage for the bundled unlock and egress direction

## Testing
- make test