### PR TITLE
docs: replace PRD with Space Age direction

### DIFF
--- a/CONVERSATION_TRANSCRIPT.md
+++ b/CONVERSATION_TRANSCRIPT.md
@@ -2,6 +2,166 @@
 
 This file captures the design interview that led to the current PRD and glossary.
 
+## Space Age Future-Direction Interview
+
+This section records the later design interview that replaced the old single-surface PRD with the current multi-planet direction.
+
+### Starting Intent
+
+**User:** Grill me on future directions for this project.
+
+### Top-Level Product Direction
+
+**Assistant:** Should the mod become a broader overhaul or stay a challenge variant?
+
+**User:** Just a challenge variant. Not broad overhaul. But incorporating in Space Age is planned.
+
+**Assistant:** Should Space Age support be a separate variant or the same core mod?
+
+**User:** Same core mod, space age aware. Also with space age it will still be expanding squares just multiple of them on different planets. Not sure about space ships yet.
+
+### Planet Model
+
+**Assistant:** Should progression be one shared empire-wide system or one independent square per planet?
+
+**User:** Independent expanding squares per planet. With rocket launches like normal space age. Space ships can remain vanilla for now.
+
+**Assistant:** Should planet unlocks stay vanilla?
+
+**User:** Same as vanilla technologies. For unlocking. Progression on the planets themselves will be specific to the planets.
+
+**Assistant:** Should expansion research be local per planet?
+
+**User:** Should simply be research like on base planet Nauvis. But with the planets specific research also required. That planet + prereq. Which means that Aquilo will be all of em except prometheum.
+
+### Rules And Tuning
+
+**Assistant:** Should the same core rules apply everywhere or should planets get distinct square rules?
+
+**User:** Same rules everywhere. Square expands. Costs research although square expansion will be research specific to planets.
+
+**Assistant:** Should expansion curve and starting size be standardized?
+
+**User:** Expansion curve tuned. Especially with playtesting. Same with starter size for planets as might need bigger or smaller for diff planets.
+
+**Assistant:** How harsh should the starting position be?
+
+**User:** Minimum size possible is ideal.
+
+**Assistant:** Expert-only theoretical minimum or realistic minimum?
+
+**User:** Expert, but tunable for an easy mode setting.
+
+**Assistant:** Presets or many knobs?
+
+**User:** A couple of presets.
+
+### Resource Model
+
+**Assistant:** Should the main puzzle remain resource purchasing or local processing?
+
+**User:** Same raw resources for free but job is to process em.
+
+**Assistant:** Should expansion points remain?
+
+**User:** Resources free, resource rate ie. more ingress still costs expansion points. But specific expansion points to that planet.
+
+**Assistant:** Should those points come only from that planet's growth?
+
+**User:** Only that planet.
+
+**Assistant:** Should free resources be universal or planet-native?
+
+**User:** Native. But up to consideration when implementing as Gleba fruit for example is farmable.
+
+**Assistant:** Should cultivated resources get free ingress?
+
+**User:** Cultivated don't get to be free ingress.
+
+### Interplanetary Logistics
+
+**Assistant:** Should imports use the ingress system?
+
+**User:** Imports are just based on normal Space Age. Ingress has nothing to do with rockets.
+
+**Assistant:** Then should vanilla imports simply be allowed, with footprint as the constraint?
+
+**User:** lgtm
+
+**Assistant:** Should the square challenge begin immediately on landing?
+
+**User:** lgtm
+
+### Starter Layouts And Egress
+
+**Assistant:** Should planet starter anchors be pre-owned, manually placed, or auto-placed?
+
+**User:** Pre-placed like on default planet Nauvis. But freely moveable by stashing and placing.
+
+**Assistant:** Hand-authored or generic per-planet layouts?
+
+**User:** Per planet implementation.
+
+**Assistant:** Should egress stay planet local?
+
+**User:** Egress is only planet local. Does not effect other planets. To effect other planets need to launch rockets.
+
+**Assistant:** What is egress for?
+
+**User:** Egress is only in the case where mining would normally consume a material like with sulfuric acid and uranium.
+
+**Assistant:** Should that be generic or explicit?
+
+**User:** Make it a reusable system for more such resources, but specific resources have to choose to use it.
+
+### Documentation And UX
+
+**Assistant:** Where should these special rules be explained?
+
+**User:** Just in the tips menu is okay.
+
+**Assistant:** Should tips hold rules and runtime UI hold live facts?
+
+**User:** lgtm
+
+### Architecture And Delivery
+
+**Assistant:** Should the code refactor to a planet-scoped model first?
+
+**User:** lgtm
+
+**Assistant:** Should the domain concept be planet-first?
+
+**User:** Just by planet is good.
+
+**Assistant:** Common implementation template or early custom code?
+
+**User:** lgtm
+
+**Assistant:** What order should planets land in?
+
+**User:** Vulcanus -> Fulgora -> Gleba -> Aquilo is good order.
+
+**Assistant:** Are breaking changes acceptable during alpha?
+
+**User:** Breaking change is okay. Its space age vs vanilla anyway. Breaking changes are okay until we get out of alpha anyway.
+
+### Final Direction
+
+The interview converged on these decisions:
+
+- The mod remains a challenge variant, not a broad overhaul.
+- The codebase remains unified and DLC-aware.
+- Nauvis remains first-class.
+- Space Age support means one independent expanding square per supported planet.
+- Planet unlocks remain vanilla; local square progression is planet-specific.
+- Expansion research, expansion points, ingress, and optional egress are local to each planet.
+- Native raw resources can be free ingress; cultivated resources stay in-square.
+- Rockets and other interplanetary logistics remain vanilla Space Age systems.
+- Egress is a reusable local mechanism that only specific resources opt into.
+- The implementation should refactor to a planet-scoped model first, then move Nauvis, then add Vulcanus, Fulgora, Gleba, and Aquilo in that order.
+- Breaking changes are acceptable during alpha.
+
 ## Initial Request
 
 **User:** Help me spec out an idea for a factorio mod with an expanding square. The square should expand in each direction 1 tile every now and then. The rate of expansion should be related (not necessarily proportional) to the percentage of the current unlocked map taken up by active machines. It should heavily incentivise automating your factorio with good space efficiency. ie. Expansion rate is much worse when a lower ratio of the map is being used. Maybe make it logarithmic/exponential? As for resources, they should be free/come in from belts/pipes off the edge of the map. And when the map expands the sources automatically moves out and adds a belt/pipe in between to keep things working. Start off with Iron on the left, copper on the right, coal above and stone below. But the player can move the resource inputs around for free. Also water should come in from another spot too. Rate starts out at 1 yellow belt, but can be upgraded. Upgrades are done manually by the player, but cost expansion points, which are received each time the map expands. Balancing is subject to playtesting. Resource inputs are raw ores. Can also buy oil/uranium/etc later. Working machines includes assembly machines, furnaces, etc, but importantly not belts, or inserters. Bots are disabled, this is a challenge. Construction bots are okay. Grill me. I just want a spec for now, don't care about implementation yet.

--- a/PRD.md
+++ b/PRD.md
@@ -1,148 +1,167 @@
-# Product Requirements Document
-
 ## Problem Statement
 
-Factorio normally rewards scaling outward across effectively unlimited terrain. That makes compact design optional and often temporary. The intended challenge for this mod is the opposite: make space the central strategic pressure by confining the player to a square that only grows when the current factory uses its unlocked area efficiently. The player should feel pushed to solve hard layout problems on purpose, rebuild often, and trade off production, science, and logistics density for faster territorial growth.
+The current mod delivers a Nauvis-centered challenge variant built around a single expanding square, research-driven growth, and managed local ingress. That works for the base game, but it does not yet provide a coherent path for Space Age. The intended future direction is not a broad overhaul or total conversion. It is a harsher, expert-first challenge variant that preserves the core identity of the mod while extending it across Space Age planets.
 
-The mod should create a run where the fun comes from choosing increasingly difficult factory-design problems:
+The current architecture is still effectively single-surface and single-bootstrap. The future design needs to support multiple independent expanding squares on different planets, planet-specific expansion research, planet-specific tuning, and planet-local ingress and expansion-point economies without turning the mod into a separate game on each surface. The user wants one coherent mod that still feels like the same challenge on Nauvis and on every supported Space Age planet.
 
-- How do I fit bootstrap power, smelting, and science into a tiny square?
-- When should I buy another input line versus upgrading all ingress throughput?
-- When should I dedicate scarce space to labs that accelerate future growth rather than to immediate production?
-- When should I rebuild the whole factory to increase active-machine utilization?
-- How do I route belts, pipes, trains, and power in a way that keeps machines both compact and highly active?
-
-The player is not trying to avoid constraint. The player is opting into a severe, legible constraint and trying to beat it through design quality.
+The main problem to solve is how to evolve the mod from a single-planet challenge into a Space Age-aware, multi-planet challenge system while preserving clarity, difficulty, and a stable design identity.
 
 ## Solution
 
-Create a Factorio challenge-mode mod built around an expanding square play area. The player starts in a very small clean square with a fixed set of free raw-resource inputs arriving from the map edge. The square expands symmetrically by one tile on all four sides whenever enough continuous expansion progress has been accumulated. Expansion progress is generated from current utilization of the unlocked square: the percentage of buildable tiles occupied by active production, research, and power-generation machines.
+Refactor the mod into a planet-scoped challenge system where each supported planet owns its own expanding square, local progression state, local expansion research, local expansion-point bank, and local ingress and optional egress rules. Nauvis remains a first-class supported experience. Space Age extends the same core rules to additional planets rather than replacing the original mode.
 
-The player earns expansion points whenever the square grows, based on the number of newly unlocked tiles. Expansion points are spent on three things only in v1:
+Each planet keeps the same core loop:
 
-- buying new input lines for resources
-- buying additional lines for already unlocked resources
-- upgrading the global ingress tier that affects all item and fluid inputs
+- the player starts inside a deliberately tiny square
+- completing that planet's square-expansion research immediately expands that planet's square
+- expansion awards expansion points for that planet only
+- those points buy additional local ingress rate or lines for that planet only
+- native raw resources for that planet can arrive through local ingress according to planet config
+- cultivated resources remain in-square production problems
+- interplanetary logistics remain vanilla Space Age and are not redefined as ingress
 
-Resources come from movable edge anchors rather than ore patches. Starter inputs are available from the beginning, additional resources are purchased later, and all inputs can be moved or stashed for free. Logistic bots and the logistic chest ecosystem are disabled by default so the puzzle remains about compact visible automation. Construction and deconstruction bots remain allowed to support frequent redesign.
-
-The result should feel like vanilla Factorio played inside a hostile optimization box: vanilla recipes and progression remain largely intact, but every tile, machine footprint, and second of machine uptime matter.
+The implementation should first extract a shared planet-scoped model and move Nauvis onto it. After that, Space Age planets should be added in a deliberate order: Vulcanus, then Fulgora, then Gleba, then Aquilo. Breaking changes are acceptable during alpha.
 
 ## User Stories
 
-1. As an early-game player, I want to start in a tiny square with working raw-resource inputs already available, so that the first challenge is layout quality rather than mining setup.
-2. As an early-game player, I want water and wood to be available from the start, so that basic power and poles are feasible inside the opening square.
-3. As an early-game player, I want the opening map to be clean and deterministic, so that I am solving a compression puzzle instead of rolling for terrain luck.
-4. As an early-game player, I want to see my utilization and expansion progress clearly, so that I can understand why my square is or is not growing.
-5. As an early-game player, I want 0% utilization to produce 0 growth, so that dead space is a real failure mode I must solve through better design.
-6. As a factory optimizer, I want only active machine footprint to count toward utilization, so that machine uptime and footprint efficiency both matter.
-7. As a factory optimizer, I want belts, inserters, poles, pipes, chests, and tanks not to count toward utilization, so that support infrastructure remains a real space cost instead of free score.
-8. As a factory optimizer, I want labs, beacons, silos, and power-generation machines to count only when truly active, so that the metric reflects real productive use rather than placed-but-idle structures.
-9. As a rebuilder, I want redesigning my factory to be cheap and friction-light, so that I can repeatedly refactor the layout without extra punishment beyond downtime.
-10. As a rebuilder, I want construction and deconstruction bots to remain available, so that large rewrites are practical even in a dense factory.
-11. As a challenge player, I want logistic bots and logistic chests disabled by default, so that the puzzle stays centered on visible space-efficient transport.
-12. As a challenge player, I want the square to expand only symmetrically, so that the entire run preserves the identity of an expanding square rather than becoming arbitrary side growth.
-13. As a challenge player, I want the world outside the square to be inaccessible void, so that the square feels like my entire playable reality.
-14. As a compact-layout player, I want starter inputs to arrive from the edge and be freely movable, so that I can reshape the border around the design I am pursuing.
-15. As a compact-layout player, I want multiple inputs on the same side when space allows, so that I can create intentionally skewed, dense layouts.
-16. As a compact-layout player, I want inputs to move outward automatically when the square expands, so that the mod preserves the border contract without breaking my factory every growth event.
-17. As a compact-layout player, I want stashed inputs to stay owned and re-placeable, so that I can simplify the current layout without losing future options.
-18. As a planner, I want stashed inputs to free their border coordinates completely, so that I can reserve edge space only for the lines I actively need.
-19. As a planner, I want stashed inputs to inherit current global ingress upgrades when placed later, so that early purchases remain strategically useful.
-20. As an economy optimizer, I want expansion points to come from newly unlocked tiles, so that larger expansions naturally produce larger strategic budgets.
-21. As an economy optimizer, I want line purchases to be flat-cost while global ingress upgrades scale by level, so that the decision between more anchors now and better anchors later remains readable.
-22. As an economy optimizer, I want the first purchased line of a resource to also be its unlock, so that expansion-point spending stays simple and concrete.
-23. As a mid-game player, I want crude oil to become available as a purchased raw input, so that oil processing still consumes internal space while extraction itself remains external.
-24. As a late-game player, I want uranium ore to become available later as another purchased raw input, so that advanced progression still participates in the ingress economy.
-25. As a vanilla-focused player, I want recipes and machines to remain mostly unchanged, so that the challenge comes from the map rule and not from memorizing a rewritten production graph.
-26. As a science-focused player, I want a repeatable expansion-speed research, so that labs remain a meaningful long-term lever on map growth.
-27. As a science-focused player, I want that repeatable research to start early and continue indefinitely, so that science competes for space and throughput across the whole run.
-28. As a science-focused player, I want dummy researches for normal science tiers, so that labs can still matter even when meaningful non-infinite research briefly runs out.
-29. As a late-game player, I want vanilla infinite research to remain available, so that the mod augments normal progression instead of replacing it.
-30. As a speedrun player, I want the run objective to stay “launch a rocket,” so that I can compare completion times on a recognizable benchmark.
-31. As a speedrun player, I want the challenge to be deterministic enough that execution and design matter more than seed luck.
-32. As a late-game player, I want play to continue indefinitely after launch, so that I can keep optimizing expansion speed, utilization, and layout quality.
-33. As a train player, I want trains to remain allowed, so that I can experiment with whether they can be justified inside a constrained square.
-34. As a manual player, I want handcrafting and hand-feeding to remain available, so that the mod does not add unnecessary rule clutter on top of the core constraint.
-35. As a power-focused player, I want self-managed power inside the square, so that electricity remains part of the compression problem rather than a free external utility.
-36. As a visibility-focused player, I want Factorio-style tips that explain the rules without prescribing strategy, so that I can learn the system and then solve it my own way.
-37. As a server host or challenge curator, I want a small set of world settings for difficulty tuning, so that I can keep the same ruleset while adjusting severity.
-38. As a mod user, I want logistics disabling to be a toggleable world setting, so that I can choose the pure challenge version or a softer variant.
-39. As a post-win optimizer, I want the square and the growth system to be effectively unbounded in design terms, so that endless improvement remains a valid goal.
-40. As a player experimenting with extreme layouts, I want the mod to accept severe congestion and awkward movement if the layout still works, so that the challenge does not get softened by quality-of-life reservations.
+1. As a challenge player, I want the mod to remain a challenge variant rather than a broad overhaul, so that the core appeal stays focused on constrained factory design.
+2. As a vanilla-focused player, I want Nauvis-only mode to remain a complete experience, so that the mod is still worth playing without Space Age.
+3. As a Space Age player, I want the same expanding-square identity to carry across planets, so that the DLC support feels like an extension of the same mod rather than a different product.
+4. As an expert player, I want each planet to have its own independent square, so that every landing creates a fresh compression puzzle.
+5. As a progression-focused player, I want planet unlocks to remain aligned with vanilla Space Age technologies, so that the larger campaign still feels recognizable.
+6. As a planner, I want each planet to have its own square-expansion research line, so that local progression is legible and self-contained.
+7. As a planner, I want each planet's square to expand immediately when its expansion research completes, so that progression stays concrete and responsive.
+8. As a challenge player, I want the same core square rules on every planet, so that the ruleset stays coherent even when tuning changes.
+9. As a balance-sensitive player, I want starting square sizes to be tuned per planet, so that each planet can be harsh without becoming arbitrarily broken.
+10. As a balance-sensitive player, I want expansion research pacing to be tuned per planet, so that different production environments can still produce a fair challenge.
+11. As an expert player, I want the default settings to target high difficulty, so that the mod preserves its intended harshness.
+12. As a broader audience player, I want a small number of easier presets, so that I can soften the experience without changing the mod's core rules.
+13. As a host or curator, I want presets to mainly tune square size and expansion pacing, so that difficulty changes are clear and predictable.
+14. As a player landing on a new planet, I want the square challenge to begin immediately, so that the mod's main constraint is never bypassed by a setup grace period.
+15. As a player landing on a new planet, I want that planet's free native inputs to already be owned, so that the bootstrap is possible from the start.
+16. As a compact-layout player, I want those free inputs to begin pre-placed in a per-planet starter layout, so that each planet has a deliberate opening puzzle.
+17. As a rebuilder, I want pre-placed anchors to remain freely movable through stashing and re-placement, so that I can redesign without artificial friction.
+18. As a player, I want planets to expose only native free resources, so that the planets feel mechanically distinct.
+19. As a player, I want cultivated resources to remain in-square problems rather than free ingress, so that planets like Gleba preserve their unique production challenge.
+20. As a Space Age player, I want vanilla interplanetary transport to remain vanilla, so that rockets and cargo mechanics are not replaced by a parallel custom transport system.
+21. As a planner, I want local ingress to represent planet-local external sourcing rather than interplanetary logistics, so that the ingress mechanic keeps a clear purpose.
+22. As an optimizer, I want each planet to have its own expansion-point bank, so that each planet's throughput economy is earned locally.
+23. As an optimizer, I want expansion points to come from square growth on that planet only, so that the local loop remains self-reinforcing and readable.
+24. As an optimizer, I want expansion points to buy additional ingress rate or lines on that same planet, so that growth and throughput remain tightly linked.
+25. As a strategist, I want cross-planet progress not to directly subsidize another planet's square growth, so that each planet remains a real challenge.
+26. As a player, I want the factory footprint required for rockets and landing infrastructure to remain part of the local square pressure, so that vanilla logistics still interact with the challenge.
+27. As a systems-minded player, I want egress to remain a local mechanic only, so that off-planet export continues to belong to vanilla rockets.
+28. As a systems-minded player, I want the mod to support reusable egress rules for resources that need local external support materials, so that special extraction cases can be modeled consistently.
+29. As a content designer, I want individual resources to opt into egress requirements explicitly, so that only the resources that need the mechanic actually use it.
+30. As a player, I want planet/resource-specific ingress and egress rules to be documented in tips, so that I can learn the rules without the runtime UI becoming overloaded.
+31. As a player, I want runtime UI to focus on live facts like local square state and local economy, so that operational information stays readable.
+32. As a developer, I want planet rules to be primarily config-driven, so that adding planets does not require rewriting the core challenge loop.
+33. As a developer, I want rare planet-specific hooks only where the shared model truly cannot express the planet, so that the system stays maintainable.
+34. As a developer, I want the code to treat planets as the primary domain concept, so that the implementation matches the design language.
+35. As a developer, I want runtime surface events mapped internally to planets, so that planet-scoped rules can still respond correctly to Factorio's surface-based APIs.
+36. As a developer, I want square state, ingress state, research state, and local economy stored per planet, so that multi-planet support does not depend on singleton global bootstrap state.
+37. As a developer, I want Nauvis migrated onto the shared planet-scoped model first, so that the architecture is proven on existing content before more planets are added.
+38. As a developer, I want Vulcanus to be the first non-Nauvis proof planet, so that the new model is tested on a materially different but not maximally pathological case.
+39. As a developer, I want the follow-up planet order to be Fulgora, then Gleba, then Aquilo, so that the rollout moves from moderate to more complex edge cases.
+40. As a tester, I want deterministic behavior-centered tests around planet-local rules, so that refactors can proceed without relying on fragile implementation details.
+41. As a tester, I want tests around per-planet research routing, so that one planet's completion cannot expand the wrong square.
+42. As a tester, I want tests around per-planet point banks and ingress purchases, so that local economies cannot leak across planets.
+43. As a tester, I want tests around native resource catalogs and starter layouts, so that each planet's bootstrap is intentional and stable.
+44. As a tester, I want tests around cultivated-resource exceptions, so that non-ingress resources like farmed outputs remain constrained correctly.
+45. As an alpha user, I want the mod to prioritize clean architecture over save compatibility, so that early refactors are not blocked by migration baggage.
+46. As a long-run player, I want endless optimization to remain supported after nominal completion, so that each planet can continue to reward refinement.
+47. As a first-win player, I want the design to optimize first for harsh but understandable completion, so that victory still feels like mastering the constraint rather than grinding a sandbox.
+48. As a challenge player, I want rebuild pain and difficulty spikes to remain acceptable, so that the mod does not get softened into a generic convenience mode.
+49. As a challenge player, I want blocking rules to remain legible rather than opaque, so that losses feel fair even when the constraints are severe.
+50. As a maintainer, I want one DLC-aware codebase rather than divergent vanilla and Space Age variants, so that the mod's shared identity and logic remain unified.
 
 ## Implementation Decisions
 
-- The play space is a centered square that begins at a configurable default size of 7x7 and grows symmetrically by one tile on every side when enough progress for a full ring has accumulated.
-- Expansion progress is continuous in the background and uses the current utilization of the unlocked square as its main driver.
-- V1 uses a linear utilization-to-growth relationship, with possible nonlinear variants deferred to later playtesting.
-- Growth is modeled as tiles per unit time with a slight size-based bonus so larger rings do not feel disproportionately slow.
-- Utilization is defined as active counted-machine footprint divided by total currently buildable tiles in the unlocked square.
-- Counted entities include active production machines, active labs, active rocket silos, active beacons affecting active machines, and active power-generation/steam-generation structures.
-- Non-counted entities include belts, undergrounds, pipes, inserters, power poles, trains-as-infrastructure, roboports, chests, tanks, logistic chests, and other support logistics.
-- A machine counts only on ticks where it is actively crafting, researching, processing, launching, or generating power by the applicable rule.
-- The world outside the square is inaccessible and unbuildable. Newly unlocked rings are clean buildable space by default.
-- Resources enter through single-tile inward-facing border anchors. Anchors can share sides but cannot overlap or collide around corners.
-- Starter inputs are iron ore, copper ore, coal, stone, water, and wood; each starts as one free ingress line at the base tier.
-- Additional resources are unlocked by buying their first line with expansion points. V1 progression is crude oil first, then uranium ore.
-- Only raw or source resources arrive from outside. Processed items and fluids remain internal production responsibilities.
-- Inputs may be relocated to any side for free or stashed off-map for later placement. No refund system exists.
-- Manual input relocation is detach-and-replace. Automatic extension only occurs when the square expands.
-- Placed inputs move outward with every expansion and preserve a simple direct border connection. Stashed inputs do not auto-extend connections because they are off-map.
-- Each purchased input line is independent. Additional lines are flat-cost in v1. Global ingress upgrades scale by level.
-- Global ingress upgrades apply retroactively to all existing and future owned lines, including stashed lines.
-- Item lines start as single-lane throughput and can be improved by later global upgrades, including a double-lane upgrade while still using one anchor tile.
-- Fluid lines use the same single-anchor concept and follow the global ingress tier progression.
-- Expansion points awarded per growth event equal the number of newly unlocked tiles in the new ring.
-- Expansion points are spent only on new lines, additional lines, and global ingress upgrades in v1.
-- Power remains the player’s problem and must be solved inside the square using the provided raw inputs.
-- Logistic robots and the logistic chest network are disabled by default, but this is exposed as a setting.
-- Construction and deconstruction bots remain allowed.
-- Vanilla combat systems are left largely untouched but become irrelevant because biters, nests, and random obstacles are absent in the default scenario.
-- The primary meaningful custom infinite research is a repeatable expansion-speed multiplier research that begins early and follows vanilla-style science tier progression over time.
-- Dummy research exists as explicit always-visible tiered filler research so labs can still have work before later infinite options naturally take over.
-- The run objective remains vanilla rocket launch, but endless post-launch play is supported.
-- Player onboarding should use concise Factorio-style help/tips entries that explain rules, not strategy.
-- Recommended deep modules for implementation are:
-  - a boundary and square-state module that owns current size, origin, and ring expansion rules
-  - a utilization evaluator that converts live world state into counted active footprint
-  - an expansion engine that converts utilization and upgrades into stored growth progress and ring expansions
-  - an ingress manager that owns input-line state, movement, stashing, and expansion-time anchor shifting
-  - an expansion-point economy that prices purchases and applies rewards
-  - a research integration module for expansion-speed research and dummy-research behavior
-  - a UI/readout module for metrics, settings surfacing, and help/tips
+- The mod remains one codebase with DLC-aware gating rather than splitting into separate vanilla and Space Age variants.
+- Vanilla-only Nauvis support remains first-class and should continue to feel complete.
+- The mod's future identity is a challenge variant, not a broad overhaul or alternate progression game.
+- The architecture should be refactored away from a single global bootstrap/surface model toward a planet-scoped domain model.
+- Planets are the primary domain concept for design, balance, and content definition.
+- Runtime plumbing may still need an internal mapping from Factorio surfaces to planet instances, but that mapping is an implementation detail, not the product model.
+- Each planet owns its own square state, expansion research progress, expansion-point bank, ingress state, optional egress state, starter layout, and tuning constants.
+- Each planet keeps the same invariant core rules:
+  - square-based play area
+  - research-driven ring expansion
+  - immediate expansion on research completion
+  - local expansion-point rewards on expansion
+  - local ingress economy
+- Per-planet tuning is allowed for:
+  - starting square size
+  - expansion research curve
+  - starter resource catalog
+  - starter anchor layout
+  - optional ingress and egress resource definitions
+  - preset overrides
+- Difficulty should be expressed through a small number of presets rather than many public knobs.
+- The easier preset should mostly make planets start larger and secondarily soften expansion pacing.
+- Each planet's free ingress resources should be native to that planet rather than a universal bundle.
+- Cultivated or farmed resources should remain in-square production problems by default and should not be exposed as free ingress.
+- Local ingress represents planet-local external sourcing only; it does not replace interplanetary rockets or cargo systems.
+- Vanilla rocket launches, travel, and interplanetary transport remain the mechanism for affecting other planets.
+- Rocket and landing infrastructure remain part of the local square-space problem.
+- Expansion points remain in the design, but they are planet-local and are spent on local ingress rate or line capacity rather than on cross-planet progression.
+- Expansion points are earned only from square growth on the same planet.
+- Egress should exist as a reusable system for local extraction-support cases, but specific resources must explicitly opt into using it.
+- Egress affects only local planet behavior and never stands in for interplanetary exports.
+- Rule explanations that are not immediately operational should live primarily in the tips system.
+- Runtime UI should stay focused on live operational state rather than carrying the full rulebook.
+- The implementation should be predominantly config-driven with rare escape hatches for genuinely exceptional planets.
+- The likely deep modules to build or reshape are:
+  - a planet registry/state store that owns all planet-scoped progression state
+  - a planet configuration catalog that defines resource sets, research metadata, starter layouts, and tuning constants
+  - a square progression module that applies local research completion to the correct planet and handles rewards
+  - a local ingress and optional egress domain module that owns anchor state, line ownership, purchases, stashing, and capacity rules per planet
+  - a runtime routing layer that maps game events and surfaces to the correct planet context
+  - a UI/tips integration layer that surfaces local live facts and planet-specific documentation
+- The delivery order should be:
+  - refactor to the planet-scoped model
+  - move Nauvis onto that model and restabilize behavior
+  - add Vulcanus
+  - add Fulgora
+  - add Gleba
+  - add Aquilo
+- Breaking changes are acceptable during alpha, especially across the vanilla-only to Space Age-aware transition.
 
 ## Testing Decisions
 
-- Good tests should verify externally visible gameplay behavior and stable domain rules, not implementation details or event ordering internals.
-- The highest-value automated tests are the ones around deterministic rules with large combinatorial risk:
-  - utilization counting behavior for included versus excluded entity classes
-  - ring-expansion progression and reward calculations
-  - anchor movement, stashing, and expansion-time preservation rules
-  - pricing and upgrade application for line purchases and global ingress tiers
-  - research effects on growth-rate multiplication and dummy-research availability
-  - settings-driven startup behavior such as square size and logistics-network disabling
-- The most important test style is domain-level scenario testing: given a square state, owned inputs, active entities, and progress, the system should produce the correct growth rate, next expansion, and rewards.
-- Module-level tests should target the deep modules described above because they encapsulate the most volatile rule combinations behind stable interfaces.
-- UI elements should be tested lightly, focusing on whether the right metrics are surfaced, not on incidental presentation details.
-- There is no codebase prior art yet in this repository, so testing conventions should be established around behavior-first ruleset tests rather than copied from existing local patterns.
+- Good tests should validate externally visible gameplay rules and stable domain behavior, not internal event ordering or storage layout details.
+- The strongest tests for this work are deterministic, planet-scoped rule tests that can assert outcomes from a given planet config and local state.
+- High-value test targets include:
+  - planet-local square progression and expansion rewards
+  - routing of completed research to the correct planet
+  - local expansion-point accrual and spending
+  - ingress ownership, stashing, movement, and capacity rules per planet
+  - starter-layout initialization per planet
+  - native-resource versus cultivated-resource handling
+  - reusable egress behavior for opted-in resources
+  - difficulty preset effects on per-planet tuning
+  - vanilla-only mode continuing to behave as a complete Nauvis challenge
+- The most important deep modules to test are the planet registry/state model, planet config interpretation, square progression, and local ingress/egress economy because they will absorb the highest combinatorial risk.
+- UI tests should remain light and behavior-focused, checking that key live facts are surfaced rather than asserting presentation internals.
+- Prior art already exists in the repository for behavior-first Lua module specs around expansion research, anchor behavior, runtime definitions, bootstrap layout, item ingress, and resource balance. The new tests should follow that style rather than introduce a different testing philosophy.
 
 ## Out of Scope
 
-- Space Age support and planet-specific resource chains
-- Non-raw external resources such as processed fluids or manufactured intermediates
-- Scoreboards, leaderboards, or bespoke endless scoring systems beyond natural speedrun timing
-- Lore, narrative framing, and thematic presentation of the void or boundary
-- Alternative nonlinear utilization formulas for v1, including exponential reward curves and anti-buffer spoilage systems
-- Any large-scale vanilla recipe overhaul
-- Formal strategy coaching, puzzle hints, or prescriptive tutorialization
-- Hard gameplay caps on map size or endless progression
-- Final balance numbers for point costs, upgrade levels, research costs, and size-bonus tuning before playtesting
-- A decision on whether blueprint ghosts may exist outside the unlocked square
-- Terrain-edit systems such as waterfill or lavafill
+- Turning the mod into a broad overhaul or rewriting vanilla production chains
+- Replacing vanilla Space Age rocket and interplanetary transport systems
+- Making imports and exports use the local ingress abstraction
+- General-purpose save migration guarantees during alpha
+- Implementing all Space Age planets in one step
+- Exhaustive live UI explanation of all custom rules
+- Large numbers of public difficulty knobs
+- Broad generic support for every imaginable external-resource edge case before a planet actually needs it
+- Decisions on spaceship-specific challenge mechanics beyond leaving them vanilla for now
+- Scoreboards, leaderboards, or a separate metagame outside the square challenge
 
 ## Further Notes
 
-- The default design should bias toward harsh constraint. If a setup is possible, it is a valid challenge candidate even if it is uncomfortable.
-- Playtesting is expected to decide the numerical balance of starting size, growth constants, input pricing, research scaling, and whether some convenience toggles deserve to graduate into defaults.
-- The intended player fantasy is not “escape the box quickly” but “become good enough at Factorio that the box expands because the factory deserves it.”
+- The design target is expert-first. The default should be severe, but the difficulty must remain understandable.
+- The intended first-win experience matters more than maximizing asymptotic system depth, though endless optimization should remain available.
+- Rebuild pain and difficulty spikes are acceptable tradeoffs. Opaque blockers are not.
+- The current codebase already expresses research-driven expansion more strongly than the older continuous-utilization PRD, so future work should preserve that newer identity unless a deliberate redesign says otherwise.
+- This PRD is a future-direction document for the alpha roadmap. It is not a promise that every listed planet or edge case will land in one release.


### PR DESCRIPTION
## Summary
- replace the old single-surface PRD with the new planet-scoped Space Age-aware direction
- document the future-direction design interview in the conversation transcript

## Testing
- not run (docs only)
