### PR TITLE
Rename branding to The Square without changing the mod id

### DIFF
--- a/CONVERSATION_TRANSCRIPT.md
+++ b/CONVERSATION_TRANSCRIPT.md
@@ -627,7 +627,7 @@ Full number is good as the ratio of lanes needed to size should remain similar o
 
 ## Artifact Requests
 
-**User:** Yes you can write a prd now. There is no github repo yet, so create one with the same name as this folder factorio-expanding-square. Also create a ubiquitous-language document and commit that. Use gh cli. Also for user stories base the as a early game player, as a late game player, as a speedrun player etc for who is playing. And focus it on the problems that they are choosing to solve for fun.
+**User:** Yes you can write a prd now. There is no github repo yet, so create one with the same name as this folder The Square. Also create a ubiquitous-language document and commit that. Use gh cli. Also for user stories base the as a early game player, as a late game player, as a speedrun player etc for who is playing. And focus it on the problems that they are choosing to solve for fun.
 
 **User:** Repo should be private
 

--- a/FEATURE_LIST.md
+++ b/FEATURE_LIST.md
@@ -1,6 +1,6 @@
 # Feature List
 
-This document lists planned features for `factorio-expanding-square`, grouped first by planned timeframe and then loosely by category.
+This document lists planned features for `The Square`, grouped first by planned timeframe and then loosely by category.
 
 ## Planned For V1
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# factorio-expanding-square
+# The Square
 
 Local development commands:
 

--- a/data.lua
+++ b/data.lua
@@ -410,7 +410,7 @@ local prototypes = {}
 prototypes[#prototypes + 1] = {
   type = "tips-and-tricks-item-category",
   name = "fes-rules",
-  order = "o[factorio-expanding-square]"
+  order = "o[the-square]"
 }
 
 prototypes[#prototypes + 1] = build_anchor_slot_proxy()

--- a/info.json
+++ b/info.json
@@ -1,8 +1,8 @@
 {
-  "name": "factorio-expanding-square",
+  "name": "the-square",
   "version": "0.1.0",
-  "title": "Factorio Expanding Square",
+  "title": "The Square",
   "author": "mmmatt",
   "factorio_version": "2.0",
-  "description": "Bootstrap scenario for an expanding-square Factorio challenge."
+  "description": "Bootstrap scenario for The Square Factorio challenge."
 }

--- a/info.json
+++ b/info.json
@@ -1,5 +1,5 @@
 {
-  "name": "the-square",
+  "name": "factorio-expanding-square",
   "version": "0.1.0",
   "title": "The Square",
   "author": "mmmatt",

--- a/lib/bootstrap_runtime.lua
+++ b/lib/bootstrap_runtime.lua
@@ -456,7 +456,7 @@ function bootstrap_runtime.expand_square(player, gui_runtime, anchor_runtime)
 
   game.print(
     {"",
-      "[Expanding Square] Square expanded from ",
+      "[The Square] Square expanded from ",
       previous_square_size,
       "x",
       previous_square_size,
@@ -554,7 +554,7 @@ function bootstrap_runtime.notify_square_size_change_applies_to_new_saves()
 
   game.print(
     {"",
-      "[Expanding Square] Starting square size changes only apply to new saves. ",
+      "[The Square] Starting square size changes only apply to new saves. ",
       "This save remains at ",
       storage.bootstrap and storage.bootstrap.square_size or "?",
       " and the current map setting is ",

--- a/lib/gui_runtime.lua
+++ b/lib/gui_runtime.lua
@@ -16,7 +16,7 @@ local function build_ingress_edge_check_debug(square_size, position)
   local detected_side = defs.get_anchor_side_for_position(square_size, tile_position)
 
   return table.concat({
-    "[Expanding Square] Ingress placement debug",
+    "[The Square] Ingress placement debug",
     "raw_position=" .. defs.format_position(position),
     "tile_position=" .. defs.format_position(tile_position),
     "square_size=" .. square_size,

--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -44,9 +44,9 @@ fes-dev-mode=Shows developer-only controls for manual expansion and the expansio
 fes-ingress-placement-debug=Prints ingress placement coordinates and edge-check details when you place an ingress item.
 
 [gui]
-fes-status-title=Expanding Square
+fes-status-title=The Square
 fes-dev-expand-button=Expand square
-fes-debug-title=Expanding Square Debug
+fes-debug-title=The Square Debug
 fes-shop-button=Line shop
 fes-shop-title=Expansion Point Shop
 fes-shop-points=Expansion points: __1__
@@ -129,10 +129,10 @@ fes-expansion-research-completed=Square expansion research reached level __1__. 
 fes-logistic-network-disabled=__1__ is disabled by this map setting.
 
 [tips-and-tricks-item-category-name]
-fes-rules=Expanding Square
+fes-rules=The Square
 
 [tips-and-tricks-item-name]
-fes-mod=Factorio Expanding Square
+fes-mod=The Square
 fes-overview=The expanding square
 fes-expansion-research=Expansion research
 fes-ingress-lines=Ingress lines

--- a/scripts/build-mod.sh
+++ b/scripts/build-mod.sh
@@ -16,7 +16,7 @@ mod_version=$(
 
 artifact_base="${mod_name}_${mod_version}"
 artifact_path="$build_dir/${artifact_base}.zip"
-stage_dir=$(mktemp -d "${TMPDIR:-/tmp}/factorio-expanding-square-build.XXXXXX")
+stage_dir=$(mktemp -d "${TMPDIR:-/tmp}/the-square-build.XXXXXX")
 package_root="$stage_dir/$artifact_base"
 
 cleanup() {

--- a/scripts/install-mod.sh
+++ b/scripts/install-mod.sh
@@ -35,6 +35,8 @@ artifact_path=$("$repo_root/scripts/build-mod.sh")
 mkdir -p "$mods_dir"
 
 find "$mods_dir" -maxdepth 1 \( -name "${mod_name}" -o -name "${mod_name}_*.zip" \) -exec rm -rf {} +
+# Clean up the short-lived incompatible package name introduced during the branding rename.
+find "$mods_dir" -maxdepth 1 \( -name "the-square" -o -name "the-square_*.zip" \) -exec rm -rf {} +
 cp "$artifact_path" "$mods_dir/"
 
 printf 'Installed %s to %s\n' "$(basename "$artifact_path")" "$mods_dir"


### PR DESCRIPTION
## Summary
- rebrand the mod display name and repo to The Square
- keep the internal Factorio mod id as `factorio-expanding-square` so existing saves remain compatible
- clean up accidentally installed `the-square` packages during install

## Testing
- make test