### PR TITLE
Remove the status infobox

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -6,7 +6,6 @@ local gui_runtime = require("lib.gui_runtime")
 local ingress_runtime = require("lib.ingress_runtime")
 
 local function sync_all_runtime_guis()
-  gui_runtime.refresh_all_status_guis()
   gui_runtime.refresh_all_debug_guis()
   gui_runtime.sync_all_shop_guis(anchor_runtime)
 end
@@ -20,7 +19,6 @@ local function handle_player_join_or_respawn(event)
 
   if player then
     bootstrap_runtime.teleport_player_to_square(player)
-    gui_runtime.sync_status_gui(player)
     gui_runtime.sync_dev_gui(player)
     gui_runtime.sync_shop_gui(player, anchor_runtime)
   end
@@ -134,7 +132,6 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
 
   if event.setting == defs.SETTING_ENABLE_LOGISTIC_NETWORK_AUTOMATION then
     anchor_runtime.apply_logistic_network_setting_to_all_forces()
-    gui_runtime.refresh_all_status_guis()
     return
   end
 
@@ -150,7 +147,6 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
       bootstrap_runtime.refresh_managed_surface_tiles(surface, storage.bootstrap.square_size, storage.bootstrap.surface_size)
     end
 
-    gui_runtime.refresh_all_status_guis()
     gui_runtime.refresh_all_debug_guis()
     return
   end
@@ -161,7 +157,6 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
     if player then
       gui_runtime.sync_dev_gui(player)
       gui_runtime.sync_shop_gui(player, anchor_runtime)
-      gui_runtime.sync_status_gui(player)
     end
   end
 end)

--- a/lib/bootstrap_runtime.lua
+++ b/lib/bootstrap_runtime.lua
@@ -503,7 +503,6 @@ function bootstrap_runtime.bootstrap_world(anchor_runtime, gui_runtime)
   end
 
   if gui_runtime then
-    gui_runtime.refresh_all_status_guis()
     gui_runtime.sync_all_dev_guis()
     gui_runtime.sync_all_shop_guis(anchor_runtime)
   end
@@ -539,7 +538,6 @@ function bootstrap_runtime.refresh_spawn_routing(anchor_runtime, gui_runtime)
   end
 
   if gui_runtime then
-    gui_runtime.refresh_all_status_guis()
     gui_runtime.sync_all_dev_guis()
     gui_runtime.sync_all_shop_guis(anchor_runtime)
   end

--- a/lib/growth_runtime.lua
+++ b/lib/growth_runtime.lua
@@ -13,7 +13,6 @@ function growth_runtime.handle_expansion_research_finished(research, bootstrap_r
   bootstrap_runtime.expand_square(game.players[1], gui_runtime, anchor_runtime)
 
   if gui_runtime then
-    gui_runtime.refresh_all_status_guis()
     gui_runtime.refresh_all_debug_guis()
   end
 

--- a/lib/gui_runtime.lua
+++ b/lib/gui_runtime.lua
@@ -88,60 +88,8 @@ local function build_status_lines()
   lines[#lines + 1] = "Next reward: " .. next_reward .. " tiles and " .. next_reward .. " expansion points"
   lines[#lines + 1] = "Expansions completed: " .. (bootstrap.expansions_completed or 0)
   lines[#lines + 1] = "Expansion points: " .. (bootstrap.expansion_points or 0)
-  lines[#lines + 1] = "Ingress tier: " .. defs.build_ingress_tier_summary()
 
   return lines
-end
-
-local function ensure_status_frame(player)
-  local frame = player.gui.left[defs.STATUS_FRAME_NAME]
-
-  if frame then
-    return frame
-  end
-
-  return player.gui.left.add({
-    type = "frame",
-    name = defs.STATUS_FRAME_NAME,
-    direction = "vertical",
-    caption = {"gui.fes-status-title"}
-  })
-end
-
-function gui_runtime.refresh_status_gui(player)
-  if not (player and player.valid) then
-    return
-  end
-
-  local frame = player.gui.left[defs.STATUS_FRAME_NAME]
-
-  if not frame then
-    return
-  end
-
-  frame.clear()
-
-  for _, line in ipairs(build_status_lines()) do
-    frame.add({
-      type = "label",
-      caption = line
-    })
-  end
-end
-
-function gui_runtime.sync_status_gui(player)
-  if not (player and player.valid) then
-    return
-  end
-
-  ensure_status_frame(player)
-  gui_runtime.refresh_status_gui(player)
-end
-
-function gui_runtime.refresh_all_status_guis()
-  for _, player in pairs(game.players) do
-    gui_runtime.sync_status_gui(player)
-  end
 end
 
 local function build_debug_lines()
@@ -257,6 +205,14 @@ function gui_runtime.refresh_shop_gui(player, anchor_runtime)
   })
   frame.add({
     type = "label",
+    caption = {
+      "gui.fes-shop-ingress-rate",
+      defs.get_current_ingress_tier().label,
+      defs.format_decimal(defs.get_ingress_item_rate_per_second())
+    }
+  })
+  frame.add({
+    type = "label",
     caption = {"gui.fes-shop-line-cost", defs.get_line_purchase_cost()}
   })
 
@@ -322,7 +278,6 @@ function gui_runtime.sync_shop_gui(player, anchor_runtime)
     return
   end
 
-  gui_runtime.sync_status_gui(player)
   ensure_shop_button(player)
   gui_runtime.refresh_shop_gui(player, anchor_runtime)
 end

--- a/lib/runtime_defs.lua
+++ b/lib/runtime_defs.lua
@@ -28,7 +28,6 @@ runtime_defs.STARTER_ANCHOR_OUTER_RING_WIDTH = 1
 runtime_defs.STARTER_ANCHOR_LAYOUT_VERSION = 12
 runtime_defs.DEV_EXPAND_BUTTON_NAME = "fes_dev_expand_button"
 runtime_defs.DEBUG_FRAME_NAME = "fes_debug_frame"
-runtime_defs.STATUS_FRAME_NAME = "fes_status_frame"
 runtime_defs.SHOP_BUTTON_NAME = "fes_shop_button"
 runtime_defs.SHOP_FRAME_NAME = "fes_shop_frame"
 runtime_defs.MAX_INGRESS_TIER = 4
@@ -503,17 +502,28 @@ end
 
 function runtime_defs.build_ingress_tier_summary()
   local tier = runtime_defs.get_current_ingress_tier()
-  local item_rate_per_second = item_ingress.get_total_items_per_second(
-    tier.item_lane_counts or {0, 0},
-    runtime_defs.ITEM_ANCHOR_INTERVAL_TICKS
-  )
-  local fluid_rate_per_second = (tier.fluid_amount_per_interval or 0) * (60 / runtime_defs.ITEM_ANCHOR_INTERVAL_TICKS)
+  local item_rate_per_second = runtime_defs.get_ingress_item_rate_per_second()
+  local fluid_rate_per_second = runtime_defs.get_ingress_fluid_rate_per_second()
 
   return tier.label
     .. " | item/s per anchor: "
     .. runtime_defs.format_decimal(item_rate_per_second)
     .. " | fluid/s per anchor: "
     .. runtime_defs.format_decimal(fluid_rate_per_second)
+end
+
+function runtime_defs.get_ingress_item_rate_per_second()
+  local tier = runtime_defs.get_current_ingress_tier()
+
+  return item_ingress.get_total_items_per_second(
+    tier.item_lane_counts or {0, 0},
+    runtime_defs.ITEM_ANCHOR_INTERVAL_TICKS
+  )
+end
+
+function runtime_defs.get_ingress_fluid_rate_per_second()
+  local tier = runtime_defs.get_current_ingress_tier()
+  return (tier.fluid_amount_per_interval or 0) * (60 / runtime_defs.ITEM_ANCHOR_INTERVAL_TICKS)
 end
 
 return runtime_defs

--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -44,12 +44,12 @@ fes-dev-mode=Shows developer-only controls for manual expansion and the expansio
 fes-ingress-placement-debug=Prints ingress placement coordinates and edge-check details when you place an ingress item.
 
 [gui]
-fes-status-title=The Square
 fes-dev-expand-button=Expand square
 fes-debug-title=The Square Debug
 fes-shop-button=Line shop
 fes-shop-title=Expansion Point Shop
 fes-shop-points=Expansion points: __1__
+fes-shop-ingress-rate=Ingress tier: __1__ (__2__ item/s per anchor)
 fes-shop-line-cost=Line cost: __1__ expansion points
 fes-shop-buy=Buy __1__
 


### PR DESCRIPTION
## Summary
- remove the always-on left-side status infobox
- show the current ingress tier item throughput in the expansion point shop header
- keep the debug panel intact while dropping the old status GUI refresh paths

## Testing
- make test