### PR TITLE
Rename mod to the-square

### DIFF
--- a/FEATURE_LIST.md
+++ b/FEATURE_LIST.md
@@ -1,6 +1,6 @@
 # Feature List
 
-This document lists planned features for `The Square`, grouped first by planned timeframe and then loosely by category.
+This document lists planned features for `the-square`, grouped first by planned timeframe and then loosely by category.
 
 ## Planned For V1
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Square
+# the-square
 
 Local development commands:
 

--- a/info.json
+++ b/info.json
@@ -1,8 +1,8 @@
 {
-  "name": "factorio-expanding-square",
+  "name": "the-square",
   "version": "0.1.0",
-  "title": "The Square",
+  "title": "the-square",
   "author": "mmmatt",
   "factorio_version": "2.0",
-  "description": "Bootstrap scenario for The Square Factorio challenge."
+  "description": "Bootstrap scenario for the-square Factorio challenge."
 }

--- a/lib/bootstrap_runtime.lua
+++ b/lib/bootstrap_runtime.lua
@@ -456,7 +456,7 @@ function bootstrap_runtime.expand_square(player, gui_runtime, anchor_runtime)
 
   game.print(
     {"",
-      "[The Square] Square expanded from ",
+      "[the-square] Square expanded from ",
       previous_square_size,
       "x",
       previous_square_size,
@@ -552,7 +552,7 @@ function bootstrap_runtime.notify_square_size_change_applies_to_new_saves()
 
   game.print(
     {"",
-      "[The Square] Starting square size changes only apply to new saves. ",
+      "[the-square] Starting square size changes only apply to new saves. ",
       "This save remains at ",
       storage.bootstrap and storage.bootstrap.square_size or "?",
       " and the current map setting is ",

--- a/lib/gui_runtime.lua
+++ b/lib/gui_runtime.lua
@@ -16,7 +16,7 @@ local function build_ingress_edge_check_debug(square_size, position)
   local detected_side = defs.get_anchor_side_for_position(square_size, tile_position)
 
   return table.concat({
-    "[The Square] Ingress placement debug",
+    "[the-square] Ingress placement debug",
     "raw_position=" .. defs.format_position(position),
     "tile_position=" .. defs.format_position(tile_position),
     "square_size=" .. square_size,

--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -45,7 +45,7 @@ fes-ingress-placement-debug=Prints ingress placement coordinates and edge-check 
 
 [gui]
 fes-dev-expand-button=Expand square
-fes-debug-title=The Square Debug
+fes-debug-title=the-square Debug
 fes-shop-button=Line shop
 fes-shop-title=Expansion Point Shop
 fes-shop-points=Expansion points: __1__
@@ -129,10 +129,10 @@ fes-expansion-research-completed=Square expansion research reached level __1__. 
 fes-logistic-network-disabled=__1__ is disabled by this map setting.
 
 [tips-and-tricks-item-category-name]
-fes-rules=The Square
+fes-rules=the-square
 
 [tips-and-tricks-item-name]
-fes-mod=The Square
+fes-mod=the-square
 fes-overview=The expanding square
 fes-expansion-research=Expansion research
 fes-ingress-lines=Ingress lines


### PR DESCRIPTION
## Summary
- rename the Factorio package id to `the-square`
- update the visible mod title, description, and user-facing labels to match
- align docs and runtime log prefixes with the new name

## Testing
- make test
- ./scripts/build-mod.sh