### PR TITLE
Prepare mod package for Mod Portal upload

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 mmmatt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/build-mod.sh
+++ b/scripts/build-mod.sh
@@ -36,6 +36,7 @@ copy_if_exists() {
 }
 
 copy_if_exists "info.json"
+copy_if_exists "LICENSE"
 copy_if_exists "control.lua"
 copy_if_exists "settings.lua"
 copy_if_exists "settings-updates.lua"


### PR DESCRIPTION
## Summary
- include `LICENSE` in the generated Factorio mod zip when present
- add an MIT `LICENSE` file to the repo
- verify the built archive uses the required `the-square_0.1.0.zip` -> `the-square_0.1.0/` layout

## Verification
- `make build`
- `make test`
- `unzip -l build/the-square_0.1.0.zip`

## Mod Portal notes
Use `MIT` for the portal license field to match the repository license.
