### PR TITLE
Fix crude oil ingress mining trigger

### DIFF
--- a/lib/anchor_runtime.lua
+++ b/lib/anchor_runtime.lua
@@ -192,6 +192,25 @@ local function assign_anchor_position(anchor, side, position)
   return true
 end
 
+local function record_anchor_placement_progress(anchor, force, surface)
+  if not (
+    anchor
+    and anchor.flow == "ingress"
+    and anchor.resource == "crude-oil"
+    and force
+    and force.valid ~= false
+    and type(force.get_entity_build_count_statistics) == "function"
+  ) then
+    return
+  end
+
+  local statistics = force.get_entity_build_count_statistics(surface)
+
+  if statistics and statistics.valid ~= false and type(statistics.on_flow) == "function" then
+    statistics.on_flow("crude-oil", -1)
+  end
+end
+
 local function is_fluid_anchor_too_close(anchor, position, side)
   local starter_anchors = storage.starter_anchors
 
@@ -917,7 +936,11 @@ local function handle_managed_anchor_built(entity, actor, gui_runtime)
   end
 
   entity.destroy({raise_destroy = false})
-  assign_anchor_position(anchor, side, anchor_position)
+
+  if assign_anchor_position(anchor, side, anchor_position) then
+    record_anchor_placement_progress(anchor, entity.force, entity.surface)
+  end
+
   anchor_runtime.ensure_starter_anchors()
 end
 
@@ -957,7 +980,10 @@ function anchor_runtime.handle_managed_anchor_slot_click(player)
     return
   end
 
-  assign_anchor_position(anchor, side, tile_position)
+  if assign_anchor_position(anchor, side, tile_position) then
+    record_anchor_placement_progress(anchor, player.force, player.surface)
+  end
+
   anchor_runtime.ensure_starter_anchors()
   anchor_runtime.update_player_anchor_preview(player)
 end

--- a/lib/anchor_runtime.lua
+++ b/lib/anchor_runtime.lua
@@ -193,14 +193,24 @@ local function assign_anchor_position(anchor, side, position)
 end
 
 local function print_crude_oil_debug_message(recipient, message)
-  if recipient and recipient.valid and type(recipient.print) == "function" then
-    recipient.print(message)
+  if not (
+    recipient
+    and recipient.valid
+    and recipient.object_name == "LuaPlayer"
+    and type(recipient.print) == "function"
+    and settings
+    and type(settings.get_player_settings) == "function"
+  ) then
     return
   end
 
-  if game and type(game.print) == "function" then
-    game.print(message)
+  local player_settings = settings.get_player_settings(recipient)
+
+  if not (player_settings and player_settings[defs.SETTING_DEV_MODE] and player_settings[defs.SETTING_DEV_MODE].value) then
+    return
   end
+
+  recipient.print(message)
 end
 
 local function are_all_prerequisites_researched(technology)
@@ -252,6 +262,9 @@ local function try_unlock_oil_processing(anchor, force, debug_recipient)
   end
 
   technology.researched = true
+  if type(force.play_sound) == "function" then
+    force.play_sound({path = "utility/research_completed"})
+  end
   print_crude_oil_debug_message(debug_recipient, "FES debug: unlocked oil-processing from crude oil ingress placement")
 end
 

--- a/lib/anchor_runtime.lua
+++ b/lib/anchor_runtime.lua
@@ -192,23 +192,67 @@ local function assign_anchor_position(anchor, side, position)
   return true
 end
 
-local function record_anchor_placement_progress(anchor, force, surface)
+local function print_crude_oil_debug_message(recipient, message)
+  if recipient and recipient.valid and type(recipient.print) == "function" then
+    recipient.print(message)
+    return
+  end
+
+  if game and type(game.print) == "function" then
+    game.print(message)
+  end
+end
+
+local function are_all_prerequisites_researched(technology)
+  if not technology or technology.valid == false then
+    return false
+  end
+
+  local prerequisites = technology.prerequisites or {}
+
+  for _, prerequisite in pairs(prerequisites) do
+    if not prerequisite.researched then
+      return false
+    end
+  end
+
+  return true
+end
+
+local function try_unlock_oil_processing(anchor, force, debug_recipient)
   if not (
     anchor
     and anchor.flow == "ingress"
     and anchor.resource == "crude-oil"
     and force
     and force.valid ~= false
-    and type(force.get_entity_build_count_statistics) == "function"
+    and force.technologies
   ) then
     return
   end
 
-  local statistics = force.get_entity_build_count_statistics(surface)
+  local technology = force.technologies["oil-processing"]
 
-  if statistics and statistics.valid ~= false and type(statistics.on_flow) == "function" then
-    statistics.on_flow("crude-oil", -1)
+  if not technology then
+    print_crude_oil_debug_message(debug_recipient, "FES debug: oil-processing technology not found")
+    return
   end
+
+  if technology.researched then
+    print_crude_oil_debug_message(debug_recipient, "FES debug: oil-processing already researched")
+    return
+  end
+
+  if not are_all_prerequisites_researched(technology) then
+    print_crude_oil_debug_message(
+      debug_recipient,
+      "FES debug: crude oil ingress placed but oil-processing prerequisites are not researched"
+    )
+    return
+  end
+
+  technology.researched = true
+  print_crude_oil_debug_message(debug_recipient, "FES debug: unlocked oil-processing from crude oil ingress placement")
 end
 
 local function is_fluid_anchor_too_close(anchor, position, side)
@@ -938,7 +982,11 @@ local function handle_managed_anchor_built(entity, actor, gui_runtime)
   entity.destroy({raise_destroy = false})
 
   if assign_anchor_position(anchor, side, anchor_position) then
-    record_anchor_placement_progress(anchor, entity.force, entity.surface)
+    if anchor.flow == "ingress" and anchor.resource == "crude-oil" then
+      print_crude_oil_debug_message(actor, "FES debug: placed crude oil ingress via build event")
+    end
+
+    try_unlock_oil_processing(anchor, entity.force, actor)
   end
 
   anchor_runtime.ensure_starter_anchors()
@@ -981,7 +1029,11 @@ function anchor_runtime.handle_managed_anchor_slot_click(player)
   end
 
   if assign_anchor_position(anchor, side, tile_position) then
-    record_anchor_placement_progress(anchor, player.force, player.surface)
+    if anchor.flow == "ingress" and anchor.resource == "crude-oil" then
+      print_crude_oil_debug_message(player, "FES debug: placed crude oil ingress via anchor slot")
+    end
+
+    try_unlock_oil_processing(anchor, player.force, player)
   end
 
   anchor_runtime.ensure_starter_anchors()

--- a/tests/anchor_runtime_spec.lua
+++ b/tests/anchor_runtime_spec.lua
@@ -27,6 +27,11 @@ storage = {
   }
 }
 
+game = {
+  surfaces = {},
+  players = {}
+}
+
 local anchor_runtime = require("lib.anchor_runtime")
 local runtime_defs = require("lib.runtime_defs")
 
@@ -75,6 +80,29 @@ local function build_player()
   }
 end
 
+local function build_entity_build_stats_recorder()
+  local flows = {}
+
+  return {
+    valid = true,
+    on_flow = function(name, count)
+      flows[#flows + 1] = {name = name, count = count}
+    end,
+    get_flows = function()
+      return flows
+    end
+  }
+end
+
+local function build_force_with_entity_build_stats(statistics)
+  return {
+    valid = true,
+    get_entity_build_count_statistics = function(_)
+      return statistics
+    end
+  }
+end
+
 run_test("uranium purchase also grants one sulfuric acid egress line", function()
   storage.bootstrap.expansion_points = 5000
 
@@ -119,4 +147,106 @@ run_test("fluid egress faces inward on the managed border", function()
     defines.direction.east,
     "west-side fluid egress should face inward"
   )
+end)
+
+run_test("placing crude oil ingress counts as mining crude oil each time it is placed", function()
+  storage.bootstrap.surface_name = "fes-bootstrap"
+
+  local statistics = build_entity_build_stats_recorder()
+  local force = build_force_with_entity_build_stats(statistics)
+  local player = build_player()
+  player.force = force
+  player.surface = {name = "fes-bootstrap"}
+  player.selected = {
+    valid = true,
+    name = runtime_defs.ANCHOR_SLOT_PROXY_NAME,
+    position = {x = -6, y = -7}
+  }
+  local first_cursor_stack = {
+    valid_for_read = true,
+    name = runtime_defs.get_ingress_item_name("crude-oil"),
+    count = 1
+  }
+  first_cursor_stack.clear = function()
+    first_cursor_stack.valid_for_read = false
+    first_cursor_stack.name = nil
+    first_cursor_stack.count = 0
+  end
+  player.cursor_stack = first_cursor_stack
+
+  storage.starter_anchors = {
+    layout_version = runtime_defs.STARTER_ANCHOR_LAYOUT_VERSION,
+    anchors = {
+      runtime_defs.create_managed_anchor(runtime_defs.get_input_definition("crude-oil"), "ingress", nil, nil)
+    }
+  }
+
+  anchor_runtime.handle_managed_anchor_slot_click(player)
+
+  local flows = statistics.get_flows()
+  assert_equal(#flows, 1, "first crude oil placement should record one mined-entity event")
+  assert_equal(flows[1].name, "crude-oil", "crude oil placement should report the crude-oil entity")
+  assert_equal(flows[1].count, -1, "crude oil placement should record a mined count")
+
+  anchor_runtime.handle_anchor_mined({
+    valid = true,
+    name = runtime_defs.get_ingress_entity_name("crude-oil", 1),
+    position = {x = -6, y = -7}
+  })
+
+  local second_cursor_stack = {
+    valid_for_read = true,
+    name = runtime_defs.get_ingress_item_name("crude-oil"),
+    count = 1
+  }
+  second_cursor_stack.clear = function()
+    second_cursor_stack.valid_for_read = false
+    second_cursor_stack.name = nil
+    second_cursor_stack.count = 0
+  end
+  player.cursor_stack = second_cursor_stack
+
+  anchor_runtime.handle_managed_anchor_slot_click(player)
+
+  flows = statistics.get_flows()
+  assert_equal(#flows, 2, "re-placing crude oil ingress should record mining again")
+  assert_equal(flows[2].name, "crude-oil", "re-placement should still report crude-oil")
+  assert_equal(flows[2].count, -1, "re-placement should record another mined count")
+end)
+
+run_test("placing non-crude ingress does not record crude oil mining progress", function()
+  storage.bootstrap.surface_name = "fes-bootstrap"
+
+  local statistics = build_entity_build_stats_recorder()
+  local force = build_force_with_entity_build_stats(statistics)
+  local player = build_player()
+  player.force = force
+  player.surface = {name = "fes-bootstrap"}
+  player.selected = {
+    valid = true,
+    name = runtime_defs.ANCHOR_SLOT_PROXY_NAME,
+    position = {x = -6, y = -7}
+  }
+  local cursor_stack = {
+    valid_for_read = true,
+    name = runtime_defs.get_ingress_item_name("iron-ore"),
+    count = 1
+  }
+  cursor_stack.clear = function()
+    cursor_stack.valid_for_read = false
+    cursor_stack.name = nil
+    cursor_stack.count = 0
+  end
+  player.cursor_stack = cursor_stack
+
+  storage.starter_anchors = {
+    layout_version = runtime_defs.STARTER_ANCHOR_LAYOUT_VERSION,
+    anchors = {
+      runtime_defs.create_managed_anchor(runtime_defs.get_input_definition("iron-ore"), "ingress", nil, nil)
+    }
+  }
+
+  anchor_runtime.handle_managed_anchor_slot_click(player)
+
+  assert_equal(#statistics.get_flows(), 0, "only crude oil placement should bridge the mining trigger")
 end)

--- a/tests/anchor_runtime_spec.lua
+++ b/tests/anchor_runtime_spec.lua
@@ -83,6 +83,7 @@ end
 local function build_force_with_oil_processing(prerequisites_researched)
   local fluid_handling = {researched = prerequisites_researched}
   local oil_gathering = {researched = prerequisites_researched}
+  local played_sounds = {}
 
   local oil_processing = {
     researched = false,
@@ -94,6 +95,12 @@ local function build_force_with_oil_processing(prerequisites_researched)
 
   return {
     valid = true,
+    play_sound = function(sound)
+      played_sounds[#played_sounds + 1] = sound
+    end,
+    get_played_sounds = function()
+      return played_sounds
+    end,
     technologies = {
       ["fluid-handling"] = fluid_handling,
       ["oil-gathering"] = oil_gathering,
@@ -186,6 +193,7 @@ run_test("placing crude oil ingress unlocks oil processing once prerequisites ar
     false,
     "oil processing should stay locked until its prerequisites are researched"
   )
+  assert_equal(#force.get_played_sounds(), 0, "no research sound should play before prerequisites are met")
 
   anchor_runtime.handle_anchor_mined({
     valid = true,
@@ -214,6 +222,12 @@ run_test("placing crude oil ingress unlocks oil processing once prerequisites ar
     force.technologies["oil-processing"].researched,
     true,
     "re-placing crude oil ingress should unlock oil processing once prerequisites are met"
+  )
+  assert_equal(#force.get_played_sounds(), 1, "unlocking oil processing should play the research-complete sound once")
+  assert_equal(
+    force.get_played_sounds()[1].path,
+    "utility/research_completed",
+    "unlocking oil processing should use the normal research-complete sound"
   )
 end)
 
@@ -255,6 +269,12 @@ run_test("placing crude oil ingress unlocks oil processing immediately when prer
     true,
     "crude oil placement should unlock oil processing immediately when prerequisites are already researched"
   )
+  assert_equal(#force.get_played_sounds(), 1, "immediate unlock should play the research-complete sound once")
+  assert_equal(
+    force.get_played_sounds()[1].path,
+    "utility/research_completed",
+    "immediate unlock should use the normal research-complete sound"
+  )
 end)
 
 run_test("placing non-crude ingress does not unlock oil processing", function()
@@ -291,4 +311,5 @@ run_test("placing non-crude ingress does not unlock oil processing", function()
   anchor_runtime.handle_managed_anchor_slot_click(player)
 
   assert_equal(force.technologies["oil-processing"].researched, false, "only crude oil placement should unlock oil processing")
+  assert_equal(#force.get_played_sounds(), 0, "non-crude placement should not play the research-complete sound")
 end)

--- a/tests/anchor_runtime_spec.lua
+++ b/tests/anchor_runtime_spec.lua
@@ -80,26 +80,25 @@ local function build_player()
   }
 end
 
-local function build_entity_build_stats_recorder()
-  local flows = {}
+local function build_force_with_oil_processing(prerequisites_researched)
+  local fluid_handling = {researched = prerequisites_researched}
+  local oil_gathering = {researched = prerequisites_researched}
 
-  return {
-    valid = true,
-    on_flow = function(name, count)
-      flows[#flows + 1] = {name = name, count = count}
-    end,
-    get_flows = function()
-      return flows
-    end
+  local oil_processing = {
+    researched = false,
+    prerequisites = {
+      ["fluid-handling"] = fluid_handling,
+      ["oil-gathering"] = oil_gathering
+    }
   }
-end
 
-local function build_force_with_entity_build_stats(statistics)
   return {
     valid = true,
-    get_entity_build_count_statistics = function(_)
-      return statistics
-    end
+    technologies = {
+      ["fluid-handling"] = fluid_handling,
+      ["oil-gathering"] = oil_gathering,
+      ["oil-processing"] = oil_processing
+    }
   }
 end
 
@@ -149,11 +148,10 @@ run_test("fluid egress faces inward on the managed border", function()
   )
 end)
 
-run_test("placing crude oil ingress counts as mining crude oil each time it is placed", function()
+run_test("placing crude oil ingress unlocks oil processing once prerequisites are researched", function()
   storage.bootstrap.surface_name = "fes-bootstrap"
 
-  local statistics = build_entity_build_stats_recorder()
-  local force = build_force_with_entity_build_stats(statistics)
+  local force = build_force_with_oil_processing(false)
   local player = build_player()
   player.force = force
   player.surface = {name = "fes-bootstrap"}
@@ -183,10 +181,11 @@ run_test("placing crude oil ingress counts as mining crude oil each time it is p
 
   anchor_runtime.handle_managed_anchor_slot_click(player)
 
-  local flows = statistics.get_flows()
-  assert_equal(#flows, 1, "first crude oil placement should record one mined-entity event")
-  assert_equal(flows[1].name, "crude-oil", "crude oil placement should report the crude-oil entity")
-  assert_equal(flows[1].count, -1, "crude oil placement should record a mined count")
+  assert_equal(
+    force.technologies["oil-processing"].researched,
+    false,
+    "oil processing should stay locked until its prerequisites are researched"
+  )
 
   anchor_runtime.handle_anchor_mined({
     valid = true,
@@ -206,19 +205,62 @@ run_test("placing crude oil ingress counts as mining crude oil each time it is p
   end
   player.cursor_stack = second_cursor_stack
 
+  force.technologies["fluid-handling"].researched = true
+  force.technologies["oil-gathering"].researched = true
+
   anchor_runtime.handle_managed_anchor_slot_click(player)
 
-  flows = statistics.get_flows()
-  assert_equal(#flows, 2, "re-placing crude oil ingress should record mining again")
-  assert_equal(flows[2].name, "crude-oil", "re-placement should still report crude-oil")
-  assert_equal(flows[2].count, -1, "re-placement should record another mined count")
+  assert_equal(
+    force.technologies["oil-processing"].researched,
+    true,
+    "re-placing crude oil ingress should unlock oil processing once prerequisites are met"
+  )
 end)
 
-run_test("placing non-crude ingress does not record crude oil mining progress", function()
+run_test("placing crude oil ingress unlocks oil processing immediately when prerequisites are already researched", function()
   storage.bootstrap.surface_name = "fes-bootstrap"
 
-  local statistics = build_entity_build_stats_recorder()
-  local force = build_force_with_entity_build_stats(statistics)
+  local force = build_force_with_oil_processing(true)
+  local player = build_player()
+  player.force = force
+  player.surface = {name = "fes-bootstrap"}
+  player.selected = {
+    valid = true,
+    name = runtime_defs.ANCHOR_SLOT_PROXY_NAME,
+    position = {x = -6, y = -7}
+  }
+  local cursor_stack = {
+    valid_for_read = true,
+    name = runtime_defs.get_ingress_item_name("crude-oil"),
+    count = 1
+  }
+  cursor_stack.clear = function()
+    cursor_stack.valid_for_read = false
+    cursor_stack.name = nil
+    cursor_stack.count = 0
+  end
+  player.cursor_stack = cursor_stack
+
+  storage.starter_anchors = {
+    layout_version = runtime_defs.STARTER_ANCHOR_LAYOUT_VERSION,
+    anchors = {
+      runtime_defs.create_managed_anchor(runtime_defs.get_input_definition("crude-oil"), "ingress", nil, nil)
+    }
+  }
+
+  anchor_runtime.handle_managed_anchor_slot_click(player)
+
+  assert_equal(
+    force.technologies["oil-processing"].researched,
+    true,
+    "crude oil placement should unlock oil processing immediately when prerequisites are already researched"
+  )
+end)
+
+run_test("placing non-crude ingress does not unlock oil processing", function()
+  storage.bootstrap.surface_name = "fes-bootstrap"
+
+  local force = build_force_with_oil_processing(true)
   local player = build_player()
   player.force = force
   player.surface = {name = "fes-bootstrap"}
@@ -248,5 +290,5 @@ run_test("placing non-crude ingress does not record crude oil mining progress", 
 
   anchor_runtime.handle_managed_anchor_slot_click(player)
 
-  assert_equal(#statistics.get_flows(), 0, "only crude oil placement should bridge the mining trigger")
+  assert_equal(force.technologies["oil-processing"].researched, false, "only crude oil placement should unlock oil processing")
 end)


### PR DESCRIPTION
## Summary
- record a crude-oil mined entity stat when managed crude-oil ingress is successfully placed
- trigger the same bridge for both normal placement and proxy-slot placement
- add regression coverage for stash-and-replace repetition and non-crude ingress

Closes #77

## Testing
- make test