### PR TITLE
Unlock uranium processing from uranium ore ingress placement

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,3 +4,4 @@ Date: 2026-03-30
   Features:
     - Added a top-bar Base screenshot button that captures the current square to script-output, with settings for pixels per tile and alt-mode overlays in the mod settings.
     - Placing a crude oil ingress now unlocks oil processing automatically once its normal prerequisites are researched (If you still need to unlock it break and replace it).
+    - Placing a uranium ore ingress now unlocks uranium processing automatically once its normal prerequisites are researched (If you still need to unlock it break and replace it).

--- a/lib/anchor_runtime.lua
+++ b/lib/anchor_runtime.lua
@@ -192,7 +192,7 @@ local function assign_anchor_position(anchor, side, position)
   return true
 end
 
-local function print_crude_oil_debug_message(recipient, message)
+local function print_anchor_debug_message(recipient, message)
   if not (
     recipient
     and recipient.valid
@@ -229,11 +229,11 @@ local function are_all_prerequisites_researched(technology)
   return true
 end
 
-local function try_unlock_oil_processing(anchor, force, debug_recipient)
+local function try_unlock_ingress_technology(anchor, force, debug_recipient, resource_name, technology_name, resource_label)
   if not (
     anchor
     and anchor.flow == "ingress"
-    and anchor.resource == "crude-oil"
+    and anchor.resource == resource_name
     and force
     and force.valid ~= false
     and force.technologies
@@ -241,22 +241,22 @@ local function try_unlock_oil_processing(anchor, force, debug_recipient)
     return
   end
 
-  local technology = force.technologies["oil-processing"]
+  local technology = force.technologies[technology_name]
 
   if not technology then
-    print_crude_oil_debug_message(debug_recipient, "FES debug: oil-processing technology not found")
+    print_anchor_debug_message(debug_recipient, "FES debug: " .. technology_name .. " technology not found")
     return
   end
 
   if technology.researched then
-    print_crude_oil_debug_message(debug_recipient, "FES debug: oil-processing already researched")
+    print_anchor_debug_message(debug_recipient, "FES debug: " .. technology_name .. " already researched")
     return
   end
 
   if not are_all_prerequisites_researched(technology) then
-    print_crude_oil_debug_message(
+    print_anchor_debug_message(
       debug_recipient,
-      "FES debug: crude oil ingress placed but oil-processing prerequisites are not researched"
+      "FES debug: " .. resource_label .. " ingress placed but " .. technology_name .. " prerequisites are not researched"
     )
     return
   end
@@ -265,7 +265,18 @@ local function try_unlock_oil_processing(anchor, force, debug_recipient)
   if type(force.play_sound) == "function" then
     force.play_sound({path = "utility/research_completed"})
   end
-  print_crude_oil_debug_message(debug_recipient, "FES debug: unlocked oil-processing from crude oil ingress placement")
+  print_anchor_debug_message(
+    debug_recipient,
+    "FES debug: unlocked " .. technology_name .. " from " .. resource_label .. " ingress placement"
+  )
+end
+
+local function try_unlock_oil_processing(anchor, force, debug_recipient)
+  try_unlock_ingress_technology(anchor, force, debug_recipient, "crude-oil", "oil-processing", "crude oil")
+end
+
+local function try_unlock_uranium_processing(anchor, force, debug_recipient)
+  try_unlock_ingress_technology(anchor, force, debug_recipient, "uranium-ore", "uranium-processing", "uranium ore")
 end
 
 local function is_fluid_anchor_too_close(anchor, position, side)
@@ -996,10 +1007,15 @@ local function handle_managed_anchor_built(entity, actor, gui_runtime)
 
   if assign_anchor_position(anchor, side, anchor_position) then
     if anchor.flow == "ingress" and anchor.resource == "crude-oil" then
-      print_crude_oil_debug_message(actor, "FES debug: placed crude oil ingress via build event")
+      print_anchor_debug_message(actor, "FES debug: placed crude oil ingress via build event")
+    end
+
+    if anchor.flow == "ingress" and anchor.resource == "uranium-ore" then
+      print_anchor_debug_message(actor, "FES debug: placed uranium ore ingress via build event")
     end
 
     try_unlock_oil_processing(anchor, entity.force, actor)
+    try_unlock_uranium_processing(anchor, entity.force, actor)
   end
 
   anchor_runtime.ensure_starter_anchors()
@@ -1043,10 +1059,15 @@ function anchor_runtime.handle_managed_anchor_slot_click(player)
 
   if assign_anchor_position(anchor, side, tile_position) then
     if anchor.flow == "ingress" and anchor.resource == "crude-oil" then
-      print_crude_oil_debug_message(player, "FES debug: placed crude oil ingress via anchor slot")
+      print_anchor_debug_message(player, "FES debug: placed crude oil ingress via anchor slot")
+    end
+
+    if anchor.flow == "ingress" and anchor.resource == "uranium-ore" then
+      print_anchor_debug_message(player, "FES debug: placed uranium ore ingress via anchor slot")
     end
 
     try_unlock_oil_processing(anchor, player.force, player)
+    try_unlock_uranium_processing(anchor, player.force, player)
   end
 
   anchor_runtime.ensure_starter_anchors()

--- a/tests/anchor_runtime_spec.lua
+++ b/tests/anchor_runtime_spec.lua
@@ -109,6 +109,32 @@ local function build_force_with_oil_processing(prerequisites_researched)
   }
 end
 
+local function build_force_with_uranium_processing(prerequisites_researched)
+  local sulfur_processing = {researched = prerequisites_researched}
+  local played_sounds = {}
+
+  local uranium_processing = {
+    researched = false,
+    prerequisites = {
+      ["sulfur-processing"] = sulfur_processing
+    }
+  }
+
+  return {
+    valid = true,
+    play_sound = function(sound)
+      played_sounds[#played_sounds + 1] = sound
+    end,
+    get_played_sounds = function()
+      return played_sounds
+    end,
+    technologies = {
+      ["sulfur-processing"] = sulfur_processing,
+      ["uranium-processing"] = uranium_processing
+    }
+  }
+end
+
 run_test("uranium purchase also grants one sulfuric acid egress line", function()
   storage.bootstrap.expansion_points = 5000
 
@@ -312,4 +338,166 @@ run_test("placing non-crude ingress does not unlock oil processing", function()
 
   assert_equal(force.technologies["oil-processing"].researched, false, "only crude oil placement should unlock oil processing")
   assert_equal(#force.get_played_sounds(), 0, "non-crude placement should not play the research-complete sound")
+end)
+
+run_test("placing uranium ore ingress unlocks uranium processing once prerequisites are researched", function()
+  storage.bootstrap.surface_name = "fes-bootstrap"
+
+  local force = build_force_with_uranium_processing(false)
+  local player = build_player()
+  player.force = force
+  player.surface = {name = "fes-bootstrap"}
+  player.selected = {
+    valid = true,
+    name = runtime_defs.ANCHOR_SLOT_PROXY_NAME,
+    position = {x = -6, y = -7}
+  }
+  local first_cursor_stack = {
+    valid_for_read = true,
+    name = runtime_defs.get_ingress_item_name("uranium-ore"),
+    count = 1
+  }
+  first_cursor_stack.clear = function()
+    first_cursor_stack.valid_for_read = false
+    first_cursor_stack.name = nil
+    first_cursor_stack.count = 0
+  end
+  player.cursor_stack = first_cursor_stack
+
+  storage.starter_anchors = {
+    layout_version = runtime_defs.STARTER_ANCHOR_LAYOUT_VERSION,
+    anchors = {
+      runtime_defs.create_managed_anchor(runtime_defs.get_input_definition("uranium-ore"), "ingress", nil, nil)
+    }
+  }
+
+  anchor_runtime.handle_managed_anchor_slot_click(player)
+
+  assert_equal(
+    force.technologies["uranium-processing"].researched,
+    false,
+    "uranium processing should stay locked until its prerequisites are researched"
+  )
+  assert_equal(#force.get_played_sounds(), 0, "no research sound should play before uranium prerequisites are met")
+
+  anchor_runtime.handle_anchor_mined({
+    valid = true,
+    name = runtime_defs.get_ingress_entity_name("uranium-ore", 1),
+    position = {x = -6, y = -7}
+  })
+
+  local second_cursor_stack = {
+    valid_for_read = true,
+    name = runtime_defs.get_ingress_item_name("uranium-ore"),
+    count = 1
+  }
+  second_cursor_stack.clear = function()
+    second_cursor_stack.valid_for_read = false
+    second_cursor_stack.name = nil
+    second_cursor_stack.count = 0
+  end
+  player.cursor_stack = second_cursor_stack
+
+  force.technologies["sulfur-processing"].researched = true
+
+  anchor_runtime.handle_managed_anchor_slot_click(player)
+
+  assert_equal(
+    force.technologies["uranium-processing"].researched,
+    true,
+    "re-placing uranium ore ingress should unlock uranium processing once prerequisites are met"
+  )
+  assert_equal(#force.get_played_sounds(), 1, "unlocking uranium processing should play the research-complete sound once")
+  assert_equal(
+    force.get_played_sounds()[1].path,
+    "utility/research_completed",
+    "unlocking uranium processing should use the normal research-complete sound"
+  )
+end)
+
+run_test("placing uranium ore ingress unlocks uranium processing immediately when prerequisites are already researched", function()
+  storage.bootstrap.surface_name = "fes-bootstrap"
+
+  local force = build_force_with_uranium_processing(true)
+  local player = build_player()
+  player.force = force
+  player.surface = {name = "fes-bootstrap"}
+  player.selected = {
+    valid = true,
+    name = runtime_defs.ANCHOR_SLOT_PROXY_NAME,
+    position = {x = -6, y = -7}
+  }
+  local cursor_stack = {
+    valid_for_read = true,
+    name = runtime_defs.get_ingress_item_name("uranium-ore"),
+    count = 1
+  }
+  cursor_stack.clear = function()
+    cursor_stack.valid_for_read = false
+    cursor_stack.name = nil
+    cursor_stack.count = 0
+  end
+  player.cursor_stack = cursor_stack
+
+  storage.starter_anchors = {
+    layout_version = runtime_defs.STARTER_ANCHOR_LAYOUT_VERSION,
+    anchors = {
+      runtime_defs.create_managed_anchor(runtime_defs.get_input_definition("uranium-ore"), "ingress", nil, nil)
+    }
+  }
+
+  anchor_runtime.handle_managed_anchor_slot_click(player)
+
+  assert_equal(
+    force.technologies["uranium-processing"].researched,
+    true,
+    "uranium ore placement should unlock uranium processing immediately when prerequisites are already researched"
+  )
+  assert_equal(#force.get_played_sounds(), 1, "immediate uranium unlock should play the research-complete sound once")
+  assert_equal(
+    force.get_played_sounds()[1].path,
+    "utility/research_completed",
+    "immediate uranium unlock should use the normal research-complete sound"
+  )
+end)
+
+run_test("placing non-uranium ingress does not unlock uranium processing", function()
+  storage.bootstrap.surface_name = "fes-bootstrap"
+
+  local force = build_force_with_uranium_processing(true)
+  local player = build_player()
+  player.force = force
+  player.surface = {name = "fes-bootstrap"}
+  player.selected = {
+    valid = true,
+    name = runtime_defs.ANCHOR_SLOT_PROXY_NAME,
+    position = {x = -6, y = -7}
+  }
+  local cursor_stack = {
+    valid_for_read = true,
+    name = runtime_defs.get_ingress_item_name("iron-ore"),
+    count = 1
+  }
+  cursor_stack.clear = function()
+    cursor_stack.valid_for_read = false
+    cursor_stack.name = nil
+    cursor_stack.count = 0
+  end
+  player.cursor_stack = cursor_stack
+
+  storage.starter_anchors = {
+    layout_version = runtime_defs.STARTER_ANCHOR_LAYOUT_VERSION,
+    anchors = {
+      runtime_defs.create_managed_anchor(runtime_defs.get_input_definition("iron-ore"), "ingress", nil, nil)
+    }
+  }
+
+  anchor_runtime.handle_managed_anchor_slot_click(player)
+
+  assert_equal(
+    force.technologies["uranium-processing"].researched,
+    false,
+    "only uranium ore placement should unlock uranium processing"
+  )
+  assert_equal(#force.get_played_sounds(), 0, "non-uranium placement should not play the research-complete sound")
 end)


### PR DESCRIPTION
## Summary
- unlock `uranium-processing` when a managed `uranium-ore` ingress is placed and its normal prerequisites are already researched
- apply the same unlock bridge for both direct placement and proxy-slot placement, without checking sulfuric acid egress runtime activity
- add regression coverage for delayed unlock, immediate unlock, and non-uranium placements

## Testing
- make test