### PR TITLE
Add terminal-first Factorio dev tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 build/
 .DS_Store
+.cache/
+.venv/
+node_modules/

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+  "runtime": {
+    "version": "Lua 5.2",
+    "path": [
+      "?.lua"
+    ],
+    "plugin": ".cache/fmtk/luals-addon/factorio/plugin.lua"
+  },
+  "workspace": {
+    "checkThirdParty": false,
+    "userThirdParty": [
+      ".cache/fmtk/luals-addon"
+    ],
+    "library": [
+      "lib",
+      "tests",
+      ".cache/fmtk/luals-addon/factorio/library"
+    ],
+    "ignoreDir": [
+      ".cache",
+      ".git",
+      ".venv",
+      "build",
+      "node_modules"
+    ]
+  },
+  "diagnostics": {
+    "globals": [
+      "__DebugAdapter",
+      "__Profiler",
+      "data",
+      "defines",
+      "mods",
+      "package",
+      "settings",
+      "storage"
+    ],
+    "disable": [
+      "lowercase-global"
+    ]
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/sh
 
 LUA ?= $(shell command -v luajit 2>/dev/null || command -v lua 2>/dev/null)
 
-.PHONY: build install test
+.PHONY: build install test tools-bootstrap luals-meta lint fmtk-package factorio-tools-install factorio-tools-dat2json factorio-tools-desync
 
 build:
 	./scripts/build-mod.sh
@@ -19,3 +19,24 @@ test:
 		echo "==> $$spec"; \
 		"$(LUA)" "$$spec" || exit 1; \
 	done
+
+tools-bootstrap:
+	./scripts/bootstrap-node-toolchain.sh
+
+luals-meta:
+	./scripts/generate-luals-addon.sh
+
+lint:
+	./scripts/lua-ls-check.sh
+
+fmtk-package:
+	./scripts/fmtk-package.sh
+
+factorio-tools-install:
+	./scripts/install-factorio-tools.sh
+
+factorio-tools-dat2json:
+	./scripts/factorio-tools.sh dat2json $(ARGS)
+
+factorio-tools-desync:
+	./scripts/factorio-tools.sh desync $(ARGS)

--- a/README.md
+++ b/README.md
@@ -8,11 +8,35 @@ Local development commands:
 make build
 make install
 make test
+make tools-bootstrap
+make luals-meta
+make lint
+make fmtk-package
 ```
 
 `make build` creates a versioned Factorio mod zip in `./build/` using the `name` and `version` from `info.json`.
 
 `make test` runs every Lua spec in `tests/*_spec.lua` and stops on the first failure. It requires either `luajit` or `lua` to be available on `PATH`; the target prefers `luajit` when both are installed.
+
+`make tools-bootstrap` installs the repo-local Node toolchain from `package.json`. Right now that is the checked-in FMTK CLI dependency used for packaging and LuaLS metadata generation.
+
+`make luals-meta` generates the FMTK LuaLS addon into `.cache/fmtk/luals-addon`. The default input is Factorio API docs from `latest`; override that with `FACTORIO_DOCS_VERSION=<exact-version>` if you need to pin analysis to a specific Factorio patch release.
+
+`make lint` runs LuaLS in terminal mode with the repo-owned [`.luarc.json`](/Users/mmmatt/projects/the-square/.luarc.json). It expects `lua-language-server` to already be installed on your machine or exposed through `LUA_LANGUAGE_SERVER=/path/to/lua-language-server`.
+
+`make fmtk-package` runs FMTK packaging into `build/fmtk/` as an additional packaging/metadata check alongside the existing custom `make build`.
+
+Optional Python tooling for desync and `.dat` inspection lives behind a separate install step:
+
+```sh
+make factorio-tools-install
+./scripts/factorio-tools.sh dat2json script.dat
+./scripts/factorio-tools.sh desync /path/to/desync-report
+```
+
+That path creates `.venv/factorio-tools` and installs the pinned PyPI package from [`requirements/factorio-tools.txt`](/Users/mmmatt/projects/the-square/requirements/factorio-tools.txt). It is intentionally optional so contributors who only need the build/test loop do not need Python tooling on day one.
+
+Terminal-first setup details, including Neovim/LSP usage, live in [docs/TERMINAL_TOOLING.md](/Users/mmmatt/projects/the-square/docs/TERMINAL_TOOLING.md).
 
 If you need to force a specific runtime, override `LUA` directly:
 

--- a/control.lua
+++ b/control.lua
@@ -123,6 +123,7 @@ script.on_event(defines.events.on_gui_click, function(event)
 end)
 
 script.on_event(defs.PLACE_MANAGED_ANCHOR_INPUT_NAME, function(event)
+  ---@cast event EventData.CustomInputEvent
   local player = game.get_player(event.player_index)
 
   if player then

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,9 @@
 # Documentation
 
-- [LORE.md](/Users/mmmatt/projects/factorio-expanding-square/docs/LORE.md): current narrative direction and writing rules
-- [conversations/2026-03-30-grill-me-ingress-lore.md](/Users/mmmatt/projects/factorio-expanding-square/docs/conversations/2026-03-30-grill-me-ingress-lore.md): lore interview notes for ingress and company framing
-- [conversations/space-age-future-direction-interview.md](/Users/mmmatt/projects/factorio-expanding-square/docs/conversations/space-age-future-direction-interview.md): earlier design interview that led to the current Space Age PRD
-- [PRD.md](/Users/mmmatt/projects/factorio-expanding-square/docs/PRD.md): current product requirements document
-- [UBIQUITOUS_LANGUAGE.md](/Users/mmmatt/projects/factorio-expanding-square/docs/UBIQUITOUS_LANGUAGE.md): shared domain terminology
-- [FEATURE_LIST.md](/Users/mmmatt/projects/factorio-expanding-square/docs/FEATURE_LIST.md): feature inventory and follow-up ideas
+- [TERMINAL_TOOLING.md](/Users/mmmatt/projects/the-square/docs/TERMINAL_TOOLING.md): repo-local CLI tooling, LuaLS, FMTK, and Factorio Tools workflows
+- [LORE.md](/Users/mmmatt/projects/the-square/docs/LORE.md): current narrative direction and writing rules
+- [conversations/2026-03-30-grill-me-ingress-lore.md](/Users/mmmatt/projects/the-square/docs/conversations/2026-03-30-grill-me-ingress-lore.md): lore interview notes for ingress and company framing
+- [conversations/space-age-future-direction-interview.md](/Users/mmmatt/projects/the-square/docs/conversations/space-age-future-direction-interview.md): earlier design interview that led to the current Space Age PRD
+- [PRD.md](/Users/mmmatt/projects/the-square/docs/PRD.md): current product requirements document
+- [UBIQUITOUS_LANGUAGE.md](/Users/mmmatt/projects/the-square/docs/UBIQUITOUS_LANGUAGE.md): shared domain terminology
+- [FEATURE_LIST.md](/Users/mmmatt/projects/the-square/docs/FEATURE_LIST.md): feature inventory and follow-up ideas

--- a/docs/TERMINAL_TOOLING.md
+++ b/docs/TERMINAL_TOOLING.md
@@ -1,0 +1,126 @@
+# Terminal Tooling
+
+This repo now treats terminal-first CLI commands as the source of truth for development tooling. Editor integrations should call into the same checked-in config and wrapper scripts instead of maintaining separate local settings.
+
+## Tooling split
+
+- Node tooling lives in [`package.json`](/Users/mmmatt/projects/the-square/package.json) and is installed repo-locally with `npm install`.
+- Python-only tooling stays Python-only and is installed into an optional repo-local virtualenv from [`requirements/factorio-tools.txt`](/Users/mmmatt/projects/the-square/requirements/factorio-tools.txt).
+- LuaLS is configured by the repo, but the `lua-language-server` binary itself stays an external install because it is not part of the npm/PyPI split used here.
+
+## Supported commands
+
+```sh
+make tools-bootstrap
+make luals-meta
+make lint
+make fmtk-package
+make factorio-tools-install
+```
+
+- `make tools-bootstrap`: installs the repo-local Node dependency set, currently FMTK.
+- `make luals-meta`: generates Factorio LuaLS metadata into `.cache/fmtk/luals-addon`.
+- `make lint`: runs `lua-language-server --check` with the repo-owned [`.luarc.json`](/Users/mmmatt/projects/the-square/.luarc.json).
+- `make fmtk-package`: runs FMTK packaging into `build/fmtk/` as a packaging and metadata validation pass in addition to the existing custom builder.
+- `make factorio-tools-install`: creates `.venv/factorio-tools` and installs Hornwitser's tools there.
+
+The wrapper scripts are:
+
+- [`scripts/fmtk.sh`](/Users/mmmatt/projects/the-square/scripts/fmtk.sh)
+- [`scripts/generate-luals-addon.sh`](/Users/mmmatt/projects/the-square/scripts/generate-luals-addon.sh)
+- [`scripts/lua-ls-check.sh`](/Users/mmmatt/projects/the-square/scripts/lua-ls-check.sh)
+- [`scripts/factorio-tools.sh`](/Users/mmmatt/projects/the-square/scripts/factorio-tools.sh)
+
+Use those directly from Codex CLI or shell automation when you need arguments that do not fit neatly into a `make` variable.
+
+## Node and FMTK
+
+Install the repo-local Node toolchain with:
+
+```sh
+make tools-bootstrap
+```
+
+That installs [`factoriomod-debug`](https://www.npmjs.com/package/factoriomod-debug) into `node_modules/` and gives the repo a stable FMTK CLI entrypoint through [`scripts/fmtk.sh`](/Users/mmmatt/projects/the-square/scripts/fmtk.sh).
+
+Current FMTK workflows:
+
+```sh
+make fmtk-package
+./scripts/fmtk.sh package --outdir build/fmtk
+./scripts/fmtk.sh luals-addon -o latest .cache/fmtk/luals-addon
+```
+
+This repo does not commit the generated LuaLS addon. It is generated on demand into `.cache/` because it is derived from upstream Factorio API docs and should stay easy to refresh when Factorio patch releases update the API surface.
+
+If you need to pin the generated addon to an exact Factorio docs release instead of `latest`, set:
+
+```sh
+FACTORIO_DOCS_VERSION=2.0.76 make luals-meta
+```
+
+## LuaLS
+
+Install `lua-language-server` yourself through your preferred package manager. For terminal-first macOS setups, Homebrew is the simplest path:
+
+```sh
+brew install lua-language-server
+```
+
+Then run:
+
+```sh
+make lint
+```
+
+The repo-owned [`.luarc.json`](/Users/mmmatt/projects/the-square/.luarc.json) defines:
+
+- Lua 5.2 runtime expectations for Factorio mod code.
+- Workspace libraries for `lib/`, `tests/`, and the generated FMTK addon.
+- Factorio globals used in this repo.
+- An ignore list for generated and tooling-only directories.
+
+Expected baseline: `make lint` should pass at the default `Warning` threshold once `lua-language-server` is installed and the FMTK addon has been generated.
+
+If you installed the binary somewhere unusual, point the wrapper at it:
+
+```sh
+LUA_LANGUAGE_SERVER=/path/to/lua-language-server make lint
+```
+
+### Neovim
+
+Point Neovim's Lua LSP at the repo root so it picks up [`.luarc.json`](/Users/mmmatt/projects/the-square/.luarc.json) automatically. With `nvim-lspconfig`, the important part is not to duplicate repo-specific settings in your personal config:
+
+```lua
+require("lspconfig").lua_ls.setup({
+  root_dir = require("lspconfig.util").root_pattern(".luarc.json", "info.json", ".git"),
+})
+```
+
+That keeps the shared repo config authoritative for Neovim, Codex CLI, and any other LuaLS client.
+
+## Hornwitser Factorio Tools
+
+Install the optional Python tools with:
+
+```sh
+make factorio-tools-install
+```
+
+That creates `.venv/factorio-tools` and installs the pinned [`hornwitser.factorio_tools`](https://pypi.org/project/hornwitser.factorio_tools/) package.
+
+Once installed, use the stable wrapper:
+
+```sh
+./scripts/factorio-tools.sh dat2json path/to/script.dat
+./scripts/factorio-tools.sh desync path/to/desync-report
+```
+
+Common expectations:
+
+- `dat2json` reads a Factorio `.dat` file and writes JSON to stdout.
+- `desync` expects a Factorio desync-report directory as input.
+- If you want to keep artifacts in-repo, put them under `build/` or another explicitly named scratch directory instead of writing into source folders.
+
+This integration is optional by design. Contributors who only need the build/test/package loop do not need to install the Python tooling.

--- a/info.json
+++ b/info.json
@@ -5,5 +5,22 @@
   "author": "mmmatt",
   "contact": "https://discord.gg/HytACasPxY",
   "factorio_version": "2.0",
+  "package": {
+    "ignore": [
+      ".cache/**",
+      ".luarc.json",
+      ".venv/**",
+      "Makefile",
+      "README.md",
+      "build/**",
+      "docs/**",
+      "node_modules/**",
+      "package-lock.json",
+      "package.json",
+      "scripts/**",
+      "tests/**"
+    ],
+    "readme": "README.md"
+  },
   "description": "The Square is a Factorio challenge mod where your factory begins inside a tiny square and can only grow by researching Square expansion.\nEach square expansion level adds one buildable tile in each direction.\n\nThe intended purpose of this mod is to constrain space and force efficient design of the factory.\n\nThis mod is pre-alpha with much tuning and playtesting still needed. Only supports the vanilla game for now but Space Age support is planned in the future.\n\nFeedback: Join the discord! https://discord.gg/HytACasPxY\n\nDisclaimer: This mod’s code was primarily AI-generated using GPT-5.4 with Codex, with human direction, review, and iteration."
 }

--- a/lib/anchor_runtime.lua
+++ b/lib/anchor_runtime.lua
@@ -772,6 +772,7 @@ function anchor_runtime.update_player_anchor_preview(player)
     return
   end
 
+  ---@cast bootstrap { square_size: integer }
   local tile_position = defs.snap_entity_position_to_tile(proxy.position)
   local side = defs.get_anchor_side_for_position(bootstrap.square_size, tile_position)
 
@@ -982,6 +983,7 @@ local function handle_managed_anchor_built(entity, actor, gui_runtime)
     gui_runtime.print_ingress_placement_debug(actor, bootstrap.square_size, entity.position)
   end
 
+  ---@cast bootstrap { square_size: integer }
   local tile_position = defs.snap_entity_position_to_tile(entity.position)
   local side = defs.get_anchor_side_for_position(bootstrap.square_size, tile_position)
   local anchor_position = tile_position
@@ -1040,6 +1042,7 @@ function anchor_runtime.handle_managed_anchor_slot_click(player)
     return
   end
 
+  ---@cast bootstrap { square_size: integer }
   local tile_position = defs.snap_entity_position_to_tile(proxy.position)
   local side = defs.get_anchor_side_for_position(bootstrap.square_size, tile_position)
 

--- a/lib/runtime_defs.lua
+++ b/lib/runtime_defs.lua
@@ -334,6 +334,7 @@ function runtime_defs.get_screenshot_pixels_per_tile()
   return 32
 end
 
+---@return boolean
 function runtime_defs.is_screenshot_alt_mode_enabled()
   local screenshot_alt_mode_setting = settings.global[runtime_defs.SETTING_SCREENSHOT_ALT_MODE]
 
@@ -341,9 +342,11 @@ function runtime_defs.is_screenshot_alt_mode_enabled()
     return true
   end
 
-  return screenshot_alt_mode_setting.value
+  return screenshot_alt_mode_setting.value == true
 end
 
+---@param square_size integer
+---@return BoundingBox
 function runtime_defs.get_anchor_bounds(square_size)
   return bootstrap_layout.get_anchor_bounds(square_size)
 end
@@ -447,6 +450,9 @@ function runtime_defs.move_position(position, side, distance)
   }
 end
 
+---@param square_size integer
+---@param position MapPosition
+---@return "north"|"east"|"south"|"west"|nil
 function runtime_defs.get_anchor_side_for_position(square_size, position)
   return bootstrap_layout.get_anchor_side_for_position(square_size, position)
 end
@@ -498,11 +504,9 @@ function runtime_defs.format_position(position)
   return "(" .. position.x .. ", " .. position.y .. ")"
 end
 
+---@param position MapPosition
+---@return MapPosition
 function runtime_defs.snap_entity_position_to_tile(position)
-  if not position then
-    return nil
-  end
-
   return {
     x = math.floor(position.x),
     y = math.floor(position.y)

--- a/lib/screenshot_runtime.lua
+++ b/lib/screenshot_runtime.lua
@@ -40,7 +40,7 @@ function screenshot_runtime.take_base_screenshot(player)
     zoom = capture.zoom,
     path = path,
     show_gui = false,
-    show_entity_info = defs.is_screenshot_alt_mode_enabled(),
+    show_entity_info = defs.is_screenshot_alt_mode_enabled() == true,
     show_cursor_building_preview = false,
     force_render = true
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "the-square-tooling",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "the-square-tooling",
+      "devDependencies": {
+        "factoriomod-debug": "^2.0.10"
+      },
+      "engines": {
+        "node": ">=22.7.0"
+      }
+    },
+    "node_modules/factoriomod-debug": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/factoriomod-debug/-/factoriomod-debug-2.0.10.tgz",
+      "integrity": "sha512-UMuf8IIs2YM3vvQim7Kd+A7MuW3b7kTb75tvDCTrRUtU4kWXdtXfPsLN64GE9tKznFE9FOUhCZWeeIEnavpvWQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "factoriomod-debug": "dist/fmtk-cli.js",
+        "fmtk": "dist/fmtk-cli.js"
+      },
+      "engines": {
+        "node": ">=22.7.0",
+        "vscode": "^1.107.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "the-square-tooling",
+  "private": true,
+  "description": "Repo-local CLI tooling for terminal-first Factorio mod development.",
+  "engines": {
+    "node": ">=22.7.0"
+  },
+  "devDependencies": {
+    "factoriomod-debug": "^2.0.10"
+  }
+}

--- a/requirements/factorio-tools.txt
+++ b/requirements/factorio-tools.txt
@@ -1,0 +1,1 @@
+hornwitser.factorio_tools==0.0.7

--- a/scripts/bootstrap-node-toolchain.sh
+++ b/scripts/bootstrap-node-toolchain.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+
+cd "$repo_root"
+npm install

--- a/scripts/factorio-tools.sh
+++ b/scripts/factorio-tools.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+venv_dir="${FACTORIO_TOOLS_VENV:-$repo_root/.venv/factorio-tools}"
+
+if [ -x "$venv_dir/bin/python" ]; then
+  exec "$venv_dir/bin/python" -m hornwitser.factorio_tools "$@"
+fi
+
+exec python3 -m hornwitser.factorio_tools "$@"

--- a/scripts/fmtk-package.sh
+++ b/scripts/fmtk-package.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+output_dir="${FMTK_PACKAGE_OUTDIR:-$repo_root/build/fmtk}"
+
+mkdir -p "$output_dir"
+exec "$repo_root/scripts/fmtk.sh" package --outdir "$output_dir"

--- a/scripts/fmtk.sh
+++ b/scripts/fmtk.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+
+if [ ! -x "$repo_root/node_modules/.bin/fmtk" ]; then
+  printf '%s\n' "error: missing repo-local Node tools. Run 'make tools-bootstrap' first." >&2
+  exit 1
+fi
+
+cd "$repo_root"
+exec npm exec -- fmtk "$@"

--- a/scripts/generate-luals-addon.sh
+++ b/scripts/generate-luals-addon.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+factorio_docs_version="${FACTORIO_DOCS_VERSION:-latest}"
+addon_dir="${LUALS_ADDON_DIR:-$repo_root/.cache/fmtk/luals-addon}"
+
+mkdir -p "$addon_dir"
+exec "$repo_root/scripts/fmtk.sh" luals-addon -o "$factorio_docs_version" "$addon_dir"

--- a/scripts/install-factorio-tools.sh
+++ b/scripts/install-factorio-tools.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+venv_dir="${FACTORIO_TOOLS_VENV:-$repo_root/.venv/factorio-tools}"
+
+python3 -m venv "$venv_dir"
+"$venv_dir/bin/pip" install --upgrade pip
+"$venv_dir/bin/pip" install -r "$repo_root/requirements/factorio-tools.txt"

--- a/scripts/lua-ls-check.sh
+++ b/scripts/lua-ls-check.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+log_dir="${LUALS_LOG_DIR:-$repo_root/build/luals}"
+check_level="${LUALS_CHECKLEVEL:-Warning}"
+lua_language_server="${LUA_LANGUAGE_SERVER:-}"
+
+if [ -z "$lua_language_server" ]; then
+  lua_language_server=$(command -v lua-language-server || true)
+fi
+
+if [ -z "$lua_language_server" ]; then
+  printf '%s\n' "error: lua-language-server is not installed. Install it and re-run 'make lint'." >&2
+  exit 1
+fi
+
+"$repo_root/scripts/generate-luals-addon.sh"
+
+rm -rf "$log_dir"
+mkdir -p "$log_dir"
+
+cd "$repo_root"
+exec "$lua_language_server" \
+  --configpath=.luarc.json \
+  --logpath="$log_dir" \
+  --check=. \
+  --checklevel="$check_level"


### PR DESCRIPTION
## Summary
- add a repo-local Node tooling bootstrap with FMTK wrappers and a committed npm manifest/lockfile
- add a project-owned LuaLS config plus terminal commands for metadata generation and static analysis
- add optional Python wrappers/docs for Hornwitser Factorio Tools and document the full terminal-first workflow

## Testing
- make test
- make fmtk-package
- make luals-meta
- make lint
- make factorio-tools-install
- ./scripts/factorio-tools.sh --help

Closes #81
Closes #82
Closes #83
Closes #84