### PR TITLE
Reconcile Managed Lines on lifecycle events

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -52,7 +52,7 @@ end)
 script.on_configuration_changed(function()
   if storage.bootstrap then
     bootstrap_runtime.ensure_bootstrap_state_defaults()
-    managed_line_runtime.ensure_state("nauvis")
+    managed_line_runtime.refresh_existing_planets()
     managed_line_runtime.sync_tier(defs.get_player_force())
 
     if storage.bootstrap.square_size ~= defs.get_square_size() then
@@ -88,7 +88,7 @@ script.on_event(defines.events.on_player_respawned, handle_player_join_or_respaw
 
 script.on_event(defines.events.on_chunk_generated, function(event)
   if bootstrap_runtime.refresh_generated_chunk_for_planet_surface(event.surface, event.area) then
-    managed_line_runtime.ensure(event.surface.name)
+    managed_line_runtime.initialize(event.surface.name)
   end
 end)
 
@@ -333,10 +333,6 @@ end)
 
 script.on_nth_tick(1, function()
   managed_line_runtime.pump_all()
-end)
-
-script.on_nth_tick(defs.ITEM_ANCHOR_INTERVAL_TICKS, function()
-  managed_line_runtime.ensure_all()
 end)
 
 script.on_nth_tick(30, function()

--- a/lib/anchor_runtime.lua
+++ b/lib/anchor_runtime.lua
@@ -136,7 +136,7 @@ local function get_anchor_state_for_surface(surface)
     return nil, nil, nil
   end
 
-  return managed_line_state.ensure(planet_name), planet, planet_name
+  return managed_line_state.get(planet_name), planet, planet_name
 end
 
 function anchor_runtime.is_managed_anchor_entity_name(entity_name)
@@ -416,10 +416,6 @@ local function ensure_anchor_slot_proxies(surface, square_size, starter_anchors,
   end
 end
 
-function anchor_runtime.ensure_starter_anchor_state()
-  return managed_line_state.ensure("nauvis")
-end
-
 local function ensure_anchor_set(surface, square_size, starter_anchors, planet_name, square_position)
   if not (surface and starter_anchors) then
     return
@@ -501,35 +497,7 @@ function anchor_runtime.unlock_planet_bootstrap_research(planet_name, force)
   end
 end
 
-function anchor_runtime.ensure_starter_anchors()
-  local bootstrap = storage.bootstrap
-
-  if not bootstrap then
-    return
-  end
-
-  local surface = game.surfaces[bootstrap.surface_name]
-
-  if not surface then
-    return
-  end
-
-  local starter_anchors = anchor_runtime.ensure_starter_anchor_state()
-
-  ensure_anchor_set(
-    surface,
-    bootstrap.square_size,
-    starter_anchors,
-    "nauvis",
-    bootstrap.square_position or {x = 0, y = 0}
-  )
-end
-
-function anchor_runtime.ensure_planet_starter_anchor_state(planet_name)
-  return managed_line_state.ensure(planet_name)
-end
-
-function anchor_runtime.ensure_planet_starter_anchors(planet_name)
+function anchor_runtime.reconcile_planet_managed_lines(planet_name)
   local planet = planet_instance.ensure(planet_name)
 
   if not planet then
@@ -542,21 +510,58 @@ function anchor_runtime.ensure_planet_starter_anchors(planet_name)
     return
   end
 
-  anchor_runtime.unlock_planet_bootstrap_research(planet_name, game.forces.player)
+  local managed_lines = managed_line_state.get(planet_name)
+
+  if not managed_lines then
+    return
+  end
+
   ensure_anchor_set(
     surface,
     planet:get_square_size(),
-    anchor_runtime.ensure_planet_starter_anchor_state(planet_name),
+    managed_lines,
     planet_name,
     planet:get_square_position()
   )
-  ensure_planet_starter_entities(surface, planet_name, planet)
 end
 
-function anchor_runtime.ensure_all_planet_starter_anchors()
-  for _, planet_name in ipairs(planet_config.SUPPORTED_PLANETS) do
-    anchor_runtime.ensure_planet_starter_anchors(planet_name)
+function anchor_runtime.refresh_planet_managed_lines(planet_name)
+  local planet = planet_instance.ensure(planet_name)
+
+  if not planet then
+    return
   end
+
+  local surface = game.surfaces[planet:get_surface_name()]
+
+  if not surface then
+    return
+  end
+
+  local managed_lines = managed_line_state.initialize(planet_name)
+
+  anchor_runtime.unlock_planet_bootstrap_research(planet_name, game.forces.player)
+  anchor_runtime.reconcile_planet_managed_lines(planet_name)
+  ensure_planet_starter_entities(surface, planet_name, planet)
+  planet.state.managed_lines_initialized = true
+
+  return managed_lines
+end
+
+function anchor_runtime.initialize_planet_managed_lines(planet_name)
+  local planet = planet_instance.ensure(planet_name)
+
+  if not planet then
+    return
+  end
+
+  local managed_lines = managed_line_state.get(planet_name)
+
+  if planet.state.managed_lines_initialized and managed_lines then
+    return managed_lines
+  end
+
+  return anchor_runtime.refresh_planet_managed_lines(planet_name)
 end
 
 function anchor_runtime.reset_rotated_anchor(entity)
@@ -790,8 +795,9 @@ function anchor_runtime.sync_anchor_tiers_from_research(force)
     return false
   end
 
-  anchor_runtime.ensure_starter_anchors()
-  anchor_runtime.ensure_all_planet_starter_anchors()
+  for _, planet_name in ipairs(planet_config.SUPPORTED_PLANETS) do
+    anchor_runtime.reconcile_planet_managed_lines(planet_name)
+  end
 
   return true
 end
@@ -1273,7 +1279,7 @@ function anchor_runtime.handle_anchor_mined(entity)
   if anchor then
     clear_anchor_managed_line(anchor)
 
-    anchor_runtime.ensure_planet_starter_anchors(planet_name)
+    anchor_runtime.reconcile_planet_managed_lines(planet_name)
   end
 end
 
@@ -1397,7 +1403,7 @@ function anchor_runtime.handle_anchor_recipe_changed(entity, actor)
   try_unlock_oil_processing(anchor, entity.force, actor)
   try_unlock_uranium_processing(anchor, entity.force, actor)
 
-  anchor_runtime.ensure_planet_starter_anchors(planet_name)
+  anchor_runtime.reconcile_planet_managed_lines(planet_name)
 
   return true
 end
@@ -1413,7 +1419,7 @@ local function get_open_anchor_for_player(player)
     return nil, nil, nil, nil
   end
 
-  local starter_anchors = managed_line_state.ensure(open_config.planet_name)
+  local starter_anchors = managed_line_state.get(open_config.planet_name)
 
   if not starter_anchors then
     return nil, nil, nil, nil
@@ -1580,7 +1586,7 @@ function anchor_runtime.handle_anchor_config_gui_click(player, element)
   local force = player.force or game and game.forces and game.forces.player
   try_unlock_oil_processing(anchor, force, player)
   try_unlock_uranium_processing(anchor, force, player)
-  anchor_runtime.ensure_planet_starter_anchors(planet_name)
+  anchor_runtime.reconcile_planet_managed_lines(planet_name)
   destroy_anchor_config_gui(player)
 
   return true

--- a/lib/bootstrap_runtime.lua
+++ b/lib/bootstrap_runtime.lua
@@ -465,13 +465,11 @@ function bootstrap_runtime.bootstrap_world(anchor_runtime, gui_runtime)
   call_freeplay("set_skip_intro", true)
   call_freeplay("set_disable_crashsite", true)
 
-  storage.starter_anchors = bootstrap_runtime.build_initial_managed_line_state("nauvis")
-
   local surface = bootstrap_runtime.ensure_bootstrap_surface(anchor_runtime)
   game.forces.player.set_spawn_position({x = 0, y = 0}, surface)
 
   if anchor_runtime then
-    anchor_runtime.ensure("nauvis")
+    anchor_runtime.initialize("nauvis")
     anchor_runtime.apply_logistic_network_setting_to_all_forces()
   end
 
@@ -513,7 +511,7 @@ function bootstrap_runtime.refresh_spawn_routing(anchor_runtime, gui_runtime)
   )
 
   if anchor_runtime then
-    anchor_runtime.ensure("nauvis")
+    anchor_runtime.reconcile("nauvis")
     anchor_runtime.apply_logistic_network_setting_to_all_forces()
   end
 

--- a/lib/managed_line_runtime.lua
+++ b/lib/managed_line_runtime.lua
@@ -2,6 +2,7 @@ local anchor_runtime = require("lib.anchor_runtime")
 local ingress_runtime = require("lib.ingress_runtime")
 local managed_line_state = require("lib.managed_line_state")
 local planet_config = require("lib.planet_config")
+local planet_instance = require("lib.planet_instance")
 
 local managed_line_runtime = {}
 
@@ -9,20 +10,23 @@ function managed_line_runtime.get(planet_name)
   return managed_line_state.get(planet_name)
 end
 
-function managed_line_runtime.ensure_state(planet_name)
-  return managed_line_state.ensure(planet_name or "nauvis")
-end
-
-function managed_line_runtime.ensure(planet_name)
+function managed_line_runtime.initialize(planet_name)
   planet_name = planet_name or "nauvis"
-  managed_line_state.ensure(planet_name)
-  return anchor_runtime.ensure_planet_starter_anchors(planet_name)
+  return anchor_runtime.initialize_planet_managed_lines(planet_name)
 end
 
-function managed_line_runtime.ensure_all()
+function managed_line_runtime.refresh_existing_planets()
   for _, planet_name in ipairs(planet_config.SUPPORTED_PLANETS) do
-    managed_line_runtime.ensure(planet_name)
+    local planet = planet_instance.ensure(planet_name)
+
+    if planet and game.surfaces[planet:get_surface_name()] then
+      anchor_runtime.refresh_planet_managed_lines(planet_name)
+    end
   end
+end
+
+function managed_line_runtime.reconcile(planet_name)
+  return anchor_runtime.reconcile_planet_managed_lines(planet_name or "nauvis")
 end
 
 function managed_line_runtime.pump(planet_name)

--- a/lib/managed_line_state.lua
+++ b/lib/managed_line_state.lua
@@ -76,7 +76,7 @@ function managed_line_state.get(planet_name)
   return planet_state and planet_state.starter_anchors or nil
 end
 
-function managed_line_state.ensure(planet_name)
+function managed_line_state.initialize(planet_name)
   planet_name = planet_name or "nauvis"
   local planet = planet_instance.ensure(planet_name)
 

--- a/lib/planet_square.lua
+++ b/lib/planet_square.lua
@@ -246,8 +246,8 @@ function planet_square.apply_square_expansion(planet_name, options)
   move_managed_lines_outward(managed_lines)
   planet_square.chart_play_area(game.forces.player, surface, next_surface_size, square_position)
 
-  if options.anchor_runtime and options.anchor_runtime.ensure then
-    options.anchor_runtime.ensure(planet_name)
+  if options.anchor_runtime and options.anchor_runtime.reconcile then
+    options.anchor_runtime.reconcile(planet_name)
   end
 
   if options.player and options.player.valid then

--- a/lib/square_move_runtime.lua
+++ b/lib/square_move_runtime.lua
@@ -319,8 +319,8 @@ function square_move_runtime.move(planet_name, direction, options)
 
   planet:set_square_position(check.target_position)
 
-  if options.managed_line_runtime and options.managed_line_runtime.ensure then
-    options.managed_line_runtime.ensure(planet_name)
+  if options.managed_line_runtime and options.managed_line_runtime.reconcile then
+    options.managed_line_runtime.reconcile(planet_name)
   end
 
   local force = options.force or game.forces.player

--- a/tests/anchor_runtime_spec.lua
+++ b/tests/anchor_runtime_spec.lua
@@ -782,7 +782,7 @@ run_test("unconfigured anchor points stay empty and keep their slot proxy", func
   local player_force = {valid = true, technologies = {}}
   local created_entities = {}
   local surface = {
-    name = "fes-bootstrap",
+    name = runtime_defs.SURFACE_NAME,
     find_entities_filtered = function()
       return {}
     end,
@@ -803,11 +803,11 @@ run_test("unconfigured anchor points stay empty and keep their slot proxy", func
   }
   game = {
     forces = {player = player_force},
-    surfaces = {["fes-bootstrap"] = surface},
+    surfaces = {[runtime_defs.SURFACE_NAME] = surface},
     players = {}
   }
   storage = {
-    bootstrap = {square_size = 12, surface_name = "fes-bootstrap", ingress_tier = 1},
+    bootstrap = {square_size = 12, surface_name = runtime_defs.SURFACE_NAME, ingress_tier = 1},
     starter_anchors = {layout_version = runtime_defs.STARTER_ANCHOR_LAYOUT_VERSION, anchors = {
       {
         kind = "fluid",
@@ -822,12 +822,16 @@ run_test("unconfigured anchor points stay empty and keep their slot proxy", func
     }}
   }
 
-  anchor_runtime.ensure_starter_anchors()
+  anchor_runtime.initialize_planet_managed_lines("nauvis")
 
   local anchor = storage.starter_anchors.anchors[1]
+  local initial_entity_count = #created_entities
+  anchor_runtime.initialize_planet_managed_lines("nauvis")
+
   assert_equal(anchor.resource, nil, "new generic Managed Lines should not configure a resource during placement")
   assert_equal(anchor.entity, nil, "unconfigured anchor points should not spawn a Managed Line entity")
   assert_equal(created_entities[1].name, runtime_defs.ANCHOR_SLOT_PROXY_NAME, "unconfigured anchor points should keep an anchor slot proxy")
+  assert_equal(#created_entities, initial_entity_count, "initialization should not reconcile a Planet more than once")
 end)
 
 run_test("existing generic item Managed Lines collapse back to anchor slot proxies", function()
@@ -845,7 +849,7 @@ run_test("existing generic item Managed Lines collapse back to anchor slot proxi
     end
   })
   local surface = {
-    name = "fes-bootstrap",
+    name = runtime_defs.SURFACE_NAME,
     find_entities_filtered = function(_, filter)
       filter = filter or _
       if filter and filter.name == generic_entity.name and filter.position then
@@ -861,11 +865,11 @@ run_test("existing generic item Managed Lines collapse back to anchor slot proxi
   }
   game = {
     forces = {player = player_force},
-    surfaces = {["fes-bootstrap"] = surface},
+    surfaces = {[runtime_defs.SURFACE_NAME] = surface},
     players = {}
   }
   storage = {
-    bootstrap = {square_size = 12, surface_name = "fes-bootstrap", ingress_tier = 1},
+    bootstrap = {square_size = 12, surface_name = runtime_defs.SURFACE_NAME, ingress_tier = 1},
     starter_anchors = {layout_version = runtime_defs.STARTER_ANCHOR_LAYOUT_VERSION, anchors = {
       {
         kind = "item",
@@ -881,7 +885,7 @@ run_test("existing generic item Managed Lines collapse back to anchor slot proxi
     }}
   }
 
-  anchor_runtime.ensure_starter_anchors()
+  anchor_runtime.initialize_planet_managed_lines("nauvis")
 
   assert_equal(storage.starter_anchors.anchors[1].entity, nil, "existing generic item Managed Line state should no longer own a visible generic entity")
 end)

--- a/tests/managed_line_runtime_spec.lua
+++ b/tests/managed_line_runtime_spec.lua
@@ -24,7 +24,8 @@ run_test("managed_line_runtime exposes only the deep Managed Line interface", fu
   storage = {}
   game = {surfaces = {}, forces = {player = {technologies = {}}}}
 
-  assert_equal(type(managed_line_runtime.ensure), "function", "Managed Line runtime should expose ensure")
+  assert_equal(type(managed_line_runtime.initialize), "function", "Managed Line runtime should expose initialization")
+  assert_equal(type(managed_line_runtime.reconcile), "function", "Managed Line runtime should expose event-driven reconciliation")
   assert_equal(type(managed_line_runtime.pump), "function", "Managed Line runtime should expose pump")
   assert_equal(type(managed_line_runtime.purchase), "function", "Managed Line runtime should expose purchase")
   assert_equal(type(managed_line_runtime.sync_tier), "function", "Managed Line runtime should expose sync_tier")
@@ -32,4 +33,16 @@ run_test("managed_line_runtime exposes only the deep Managed Line interface", fu
   assert_equal(type(managed_line_runtime.get_owned_line_counts), "function", "Managed Line runtime should expose shop queries")
   assert_equal(type(managed_line_runtime.purchase_managed_line_for_resource), "nil", "legacy purchase export should not leak through the seam")
   assert_equal(type(managed_line_runtime.sync_ingress_tier_from_research), "nil", "legacy tier export should not leak through the seam")
+end)
+
+run_test("control does not schedule recurring Managed Line reconciliation", function()
+  local control_file = assert(io.open("control.lua", "r"))
+  local source = control_file:read("*a")
+  control_file:close()
+
+  assert_equal(
+    source:match("on_nth_tick%s*%(%s*defs%.ITEM_ANCHOR_INTERVAL_TICKS"),
+    nil,
+    "Managed Line reconciliation should be triggered by lifecycle events, not a recurring tick"
+  )
 end)

--- a/tests/managed_line_state_spec.lua
+++ b/tests/managed_line_state_spec.lua
@@ -20,11 +20,11 @@ local function run_test(name, fn)
   io.stdout:write("PASS " .. name .. "\n")
 end
 
-run_test("same Managed Line state seam ensures and reads Nauvis and Proof Planet lines", function()
+run_test("same Managed Line state seam initializes and reads Nauvis and Proof Planet lines", function()
   storage = {bootstrap = {square_size = 7, surface_name = "nauvis"}}
 
-  local nauvis_lines = managed_line_state.ensure("nauvis")
-  local vulcanus_lines = managed_line_state.ensure("vulcanus")
+  local nauvis_lines = managed_line_state.initialize("nauvis")
+  local vulcanus_lines = managed_line_state.initialize("vulcanus")
 
   assert_equal(managed_line_state.get("nauvis"), nauvis_lines, "Nauvis lines should be readable through the seam")
   assert_equal(managed_line_state.get("vulcanus"), vulcanus_lines, "Proof Planet lines should be readable through the seam")
@@ -36,6 +36,18 @@ end)
 run_test("seam returns nil for unsupported planets without creating Managed Lines", function()
   storage = {}
 
-  assert_equal(managed_line_state.ensure("not-a-planet"), nil, "unsupported Planet should not have Managed Lines")
+  assert_equal(managed_line_state.initialize("not-a-planet"), nil, "unsupported Planet should not have Managed Lines")
   assert_equal(managed_line_state.get("not-a-planet"), nil, "unsupported Planet should not read Managed Lines")
+end)
+
+run_test("starter Managed Lines initialize only once per Planet", function()
+  storage = {bootstrap = {square_size = 7, surface_name = "nauvis"}}
+
+  local initial_lines = managed_line_state.initialize("nauvis")
+  initial_lines.anchors[#initial_lines.anchors + 1] = {resource = "coal"}
+  local initialized_again = managed_line_state.initialize("nauvis")
+
+  assert_equal(initialized_again, initial_lines, "initialization should preserve the Planet's existing Managed Line state")
+  assert_equal(#initialized_again.anchors, 4, "initialization should not regenerate the Starter Layout")
+  assert_equal(initialized_again.anchors[4].resource, "coal", "initialization should preserve lines added after startup")
 end)

--- a/tests/planet_square_runtime_spec.lua
+++ b/tests/planet_square_runtime_spec.lua
@@ -64,9 +64,9 @@ run_test("Planet Square runtime expands one Planet-local Square through one inte
     }
   }
   local refreshed = false
-  local ensured_planet = nil
+  local reconciled_planet = nil
   local gui_runtime = {refresh_all_debug_guis = function() refreshed = true end}
-  local managed_line_runtime = {ensure = function(planet_name) ensured_planet = planet_name end}
+  local managed_line_runtime = {reconcile = function(planet_name) reconciled_planet = planet_name end}
 
   local result = planet_square_runtime.expand("vulcanus", {
     gui_runtime = gui_runtime,
@@ -76,7 +76,7 @@ run_test("Planet Square runtime expands one Planet-local Square through one inte
   assert_equal(result.square_size, 7, "runtime should grow the Planet Square")
   assert_equal(storage.planets.vulcanus.expansion_research_levels, 1, "runtime should advance Planet Progression")
   assert_equal(refreshed, true, "runtime should own expansion GUI refresh")
-  assert_equal(ensured_planet, "vulcanus", "runtime should pass Managed Line adapter through for Managed Line Shift repair")
+  assert_equal(reconciled_planet, "vulcanus", "runtime should reconcile Managed Lines after shifting them")
 end)
 
 run_test("Planet Square runtime handles Square Expansion research without bootstrap_runtime", function()

--- a/tests/space_age_starter_runtime_spec.lua
+++ b/tests/space_age_starter_runtime_spec.lua
@@ -7,6 +7,7 @@ game = {forces = {player = {valid = true, mining_drill_productivity_bonus = 0}}}
 
 local anchor_runtime = require("lib.anchor_runtime")
 local ingress_runtime = require("lib.ingress_runtime")
+local managed_line_state = require("lib.managed_line_state")
 local defs = require("lib.runtime_defs")
 
 local function assert_equal(actual, expected, message)
@@ -25,8 +26,8 @@ local function run_test(name, fn)
 end
 
 run_test("non-Nauvis planets start without free Managed Lines in isolated storage", function()
-  local vulcanus = anchor_runtime.ensure_planet_starter_anchor_state("vulcanus")
-  local gleba = anchor_runtime.ensure_planet_starter_anchor_state("gleba")
+  local vulcanus = managed_line_state.initialize("vulcanus")
+  local gleba = managed_line_state.initialize("gleba")
 
   assert_equal(#vulcanus.anchors, 0, "Vulcanus should not get free starter lines")
   assert_equal(#gleba.anchors, 0, "Gleba should not get free starter lines")

--- a/tests/square_move_runtime_spec.lua
+++ b/tests/square_move_runtime_spec.lua
@@ -220,12 +220,12 @@ run_test("Moving the Square updates tiles and Boundary state without moving fact
   local assembler = make_entity("assembling-machine", {x = 0, y = 0})
   local surface = make_surface({departing_belt, assembler})
   install_world(surface, {west_anchor, east_anchor, north_anchor})
-  local ensured_planet = nil
+  local reconciled_planet = nil
 
   local result = square_move_runtime.move("nauvis", "east", {
     managed_line_runtime = {
-      ensure = function(planet_name)
-        ensured_planet = planet_name
+      reconcile = function(planet_name)
+        reconciled_planet = planet_name
       end
     }
   })
@@ -242,7 +242,7 @@ run_test("Moving the Square updates tiles and Boundary state without moving fact
   assert_equal(surface.map_gen_settings.width, 11, "the finite surface should grow to contain the moved Square")
   assert_equal(surface.map_gen_settings.height, 9, "an east move should not grow the surface vertically")
   assert_equal(type(surface.tiles_set), "table", "playable and Void tiles should be rewritten")
-  assert_equal(ensured_planet, "nauvis", "Managed Lines should be repaired after the Boundary moves")
+  assert_equal(reconciled_planet, "nauvis", "Managed Lines should be reconciled after the Boundary moves")
   assert_equal(game.spawn_position.x, 1, "the force spawn should follow the moved Square")
 end)
 


### PR DESCRIPTION
## Summary

- initialize each Planet's Starter Layout once and guard repeated chunk-generation initialization
- use the same generic Managed Line initialization and reconciliation path for Nauvis and Space Age planets
- reconcile on explicit lifecycle events such as Square expansion/movement, tier changes, mining, and configuration
- remove the recurring eight-tick Managed Line reconciliation pass
- retain the Nauvis legacy storage alias only for existing-save compatibility

## Validation

- `make typecheck`
- `make test`
  - unit tests
  - Factorio load test
  - Factorio default-world creation test