### PR TITLE
Keep changelog entries player-facing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,4 +5,8 @@ This project is a mod for the game Factorio.
 control.lua is reloaded on world creation
 settings.lua and data.lua on game startup
 
+changelog.txt is a user-facing changelog. Include only changes that are visible to players.
+Do not include developer-only refactors, cleanup, tests, tooling, or other internal changes.
+Follow Factorio's changelog format: https://lua-api.factorio.com/latest/auxiliary/changelog-format.html
+
 See CONTEXT.md for a glossary of terms

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,10 +2,8 @@
 Version: 0.1.5
 Date: 2026-07-30
   Features:
-    - Added a movement UI toggle that can shift factory contents and placed tiles while leaving the Square and players fixed and keeping Managed Lines aligned along the Boundary.
-  Changes:
-    - Consolidated persisted Square state under the planet model.
-    - Removed legacy Line Shop code now that Managed Lines are crafted and configured through Anchor slots.
+    - Added Move Square controls that can move the playable Square and its Boundary while leaving factory contents in place.
+    - Added a Square / Contents toggle that can instead shift factory entities and placed tiles while leaving the Square and players fixed and keeping Managed Lines aligned along the Boundary.
 
 ---------------------------------------------------------------------------------------------------
 Version: 0.1.4


### PR DESCRIPTION
## Summary

- document that `changelog.txt` contains only player-visible changes and excludes internal refactors, cleanup, tests, and tooling
- link the official [Factorio changelog format](https://lua-api.factorio.com/latest/auxiliary/changelog-format.html) from `AGENTS.md`
- audit all changes since the `0.1.4` release commit (`669a085fc1eac78071208e9d0b2873561973c034`)
- remove internal-only `0.1.5` notes and document both player-facing Square movement modes

## Validation

- changelog separator, version, category, and entry indentation validation
- no tabs or trailing whitespace in `AGENTS.md` or `changelog.txt`
- `git diff --check`
- `make build`
