### PR TITLE
Document version release marker flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,4 +9,21 @@ changelog.txt is a user-facing changelog. Include only changes that are visible 
 Do not include developer-only refactors, cleanup, tests, tooling, or other internal changes.
 Follow Factorio's changelog format: https://lua-api.factorio.com/latest/auxiliary/changelog-format.html
 
+## Version and release flow
+
+A version bump starts development for that version; it does not mark a release. Bump info.json
+early when needed for migrations and testing, and allow any number of subsequent commits to
+implement and validate that version.
+
+A version is released only when an explicit release marker commit and matching annotated Git
+tag exist. After all changes for a version are merged, its user-facing changelog is finalized,
+and validation passes:
+
+1. Start from a clean, up-to-date main branch.
+2. Create an empty commit named exactly `Release vX.Y.Z`.
+3. Create an annotated tag named `vX.Y.Z` on that commit with the message `Release vX.Y.Z`.
+
+Do not create the release marker commit or tag merely because info.json was bumped. The tag is
+the authoritative release boundary when auditing changes since a previous release.
+
 See CONTEXT.md for a glossary of terms


### PR DESCRIPTION
## Summary

- document that version bumps may happen early to support migration development and testing
- allow a version's work to span any number of commits without implying it has been released
- define an explicit empty `Release vX.Y.Z` commit plus matching annotated `vX.Y.Z` tag as the authoritative release boundary
- instruct contributors not to create a release marker merely because `info.json` changed

This PR only documents the flow. It does not create a `v0.1.5` release commit or tag.

## Validation

- `git diff --check`
- checked `AGENTS.md` for tabs and trailing whitespace
- verified all release-flow invariants are present
