### PR TITLE
Remove unusable starter mining drill

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.1.6
+  Balancing:
+    - Removed the burner mining drill from the starting inventory because there are no resource patches to mine.
+
+---------------------------------------------------------------------------------------------------
 Version: 0.1.5
 Date: 2026-07-30
   Features:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "the-square",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "title": "The Square",
   "author": "mmmatt",
   "contact": "https://discord.gg/HytACasPxY",

--- a/lib/planet_runtime.lua
+++ b/lib/planet_runtime.lua
@@ -185,7 +185,27 @@ end
 
 local function call_freeplay(interface_name, value)
   if remote.interfaces.freeplay and remote.interfaces.freeplay[interface_name] then
-    remote.call("freeplay", interface_name, value)
+    return remote.call("freeplay", interface_name, value)
+  end
+end
+
+function planet_runtime.configure_freeplay()
+  call_freeplay("set_skip_intro", true)
+  call_freeplay("set_disable_crashsite", true)
+
+  if not (
+    remote.interfaces.freeplay
+    and remote.interfaces.freeplay.get_created_items
+    and remote.interfaces.freeplay.set_created_items
+  ) then
+    return
+  end
+
+  local created_items = call_freeplay("get_created_items")
+
+  if created_items then
+    created_items["burner-mining-drill"] = nil
+    call_freeplay("set_created_items", created_items)
   end
 end
 
@@ -459,8 +479,7 @@ function planet_runtime.expand_planet_square(planet_name, player, gui_runtime, a
 end
 
 function planet_runtime.initialize_world(anchor_runtime, gui_runtime)
-  call_freeplay("set_skip_intro", true)
-  call_freeplay("set_disable_crashsite", true)
+  planet_runtime.configure_freeplay()
 
   local surface = planet_runtime.initialize_planet_surface("nauvis")
   game.forces.player.set_spawn_position({x = 0, y = 0}, surface)
@@ -495,8 +514,7 @@ function planet_runtime.refresh_spawn_routing(planet_name, anchor_runtime, gui_r
     return
   end
 
-  call_freeplay("set_skip_intro", true)
-  call_freeplay("set_disable_crashsite", true)
+  planet_runtime.configure_freeplay()
   local square_position = planet:get_square_position()
   game.forces.player.set_spawn_position(square_position, surface)
   ensure_surface_dimensions(

--- a/tests/planet_runtime_spec.lua
+++ b/tests/planet_runtime_spec.lua
@@ -102,6 +102,38 @@ run_test("initial Managed Line inventory is granted once", function()
   assert_equal(inserted[defs.get_generic_anchor_item_name("item", "ingress")], 2, "player should receive two item ingresses")
 end)
 
+run_test("freeplay starting items omit the burner mining drill", function()
+  local created_items = {
+    ["burner-mining-drill"] = 1,
+    ["stone-furnace"] = 1
+  }
+
+  remote = {
+    interfaces = {
+      freeplay = {
+        get_created_items = true,
+        set_created_items = true,
+        set_disable_crashsite = true,
+        set_skip_intro = true
+      }
+    },
+    call = function(_, interface_name, value)
+      if interface_name == "get_created_items" then
+        return created_items
+      end
+
+      if interface_name == "set_created_items" then
+        created_items = value
+      end
+    end
+  }
+
+  planet_runtime.configure_freeplay()
+
+  assert_equal(created_items["burner-mining-drill"], nil, "new players should not receive an unusable mining drill")
+  assert_equal(created_items["stone-furnace"], 1, "other freeplay starting items should remain unchanged")
+end)
+
 run_test("generated chunks on supported Space Age planet surfaces are routed through planet state", function()
   storage = {}
   local painted_tiles = nil


### PR DESCRIPTION
The burner mining drill serves no purpose in The Square because resource patches are replaced by Managed Lines. New players now start without it, while every other freeplay starting item remains unchanged.

This also starts development of version 0.1.6 and records the player-facing balance change.

Closes #144

---

The freeplay configuration reads the scenario's current starting-item map, removes only `burner-mining-drill`, and writes it back. This preserves starting items supplied by Factorio or other mods and does not alter existing player inventories.

Validation:

- `make typecheck`
- `make unit-test`
- `make build`

Factorio end-to-end tests were not run because a Factorio binary is not available in this environment.

Made with GPT-5.6 Sol in the Codex harness.
