### PR TITLE
Run end-to-end tests only on request

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,8 @@ This project is a mod for the game Factorio.
 control.lua is reloaded on world creation
 settings.lua and data.lua on game startup
 
+Only run end-to-end (e2e) tests when explicitly asked.
+
 changelog.txt is a user-facing changelog. Include changes that are visible to players.
 Significant internal refactors may be mentioned in broad, non-technical terms when useful for
 setting player expectations, but do not describe their implementation details. Do not include


### PR DESCRIPTION
End-to-end tests should not run as part of routine validation unless they are specifically requested. This adds that boundary to the project instructions so future work follows it consistently.

---

Validation: `git diff --check`

No tests run because this is a documentation-only change.

Created with GPT-5.6-sol via T3 Code (Codex harness).